### PR TITLE
FRCNN support for Caffe

### DIFF
--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -93,6 +93,10 @@ using std::string;
 using std::stringstream;
 using std::vector;
 
+#ifdef _MSC_VER
+#define snprintf _snprintf
+#endif
+
 // A global initialization function that you should call in your main function.
 // Currently it initializes google flags and google logging.
 void GlobalInit(int* pargc, char*** pargv);

--- a/include/caffe/layer.hpp
+++ b/include/caffe/layer.hpp
@@ -291,6 +291,8 @@ class Layer {
     param_propagate_down_[param_id] = value;
   }
 
+  inline Phase phase() { return phase_; }
+
 
  protected:
   /** The protobuf that stores the layer parameters */

--- a/include/caffe/layer.hpp
+++ b/include/caffe/layer.hpp
@@ -293,6 +293,15 @@ class Layer {
 
   inline Phase phase() { return phase_; }
 
+  /**
+   * @brief set phase
+   *        enable train and test with one network, for saving memory
+  */
+  virtual inline void set_phase(Phase phase){
+    phase_ = phase;
+  }
+
+
 
  protected:
   /** The protobuf that stores the layer parameters */

--- a/include/caffe/layer.hpp
+++ b/include/caffe/layer.hpp
@@ -297,7 +297,7 @@ class Layer {
    * @brief set phase
    *        enable train and test with one network, for saving memory
   */
-  virtual inline void set_phase(Phase phase){
+  virtual inline void set_phase(Phase phase) {
     phase_ = phase;
   }
 

--- a/include/caffe/layers/box_annotator_ohem_layer.hpp
+++ b/include/caffe/layers/box_annotator_ohem_layer.hpp
@@ -19,7 +19,7 @@ namespace caffe {
  */
   template <typename Dtype>
   class BoxAnnotatorOHEMLayer :public Layer<Dtype>{
-  public:
+   public:
     explicit BoxAnnotatorOHEMLayer(const LayerParameter& param)
       : Layer<Dtype>(param) {}
     virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
@@ -32,7 +32,7 @@ namespace caffe {
     virtual inline int ExactNumBottomBlobs() const { return 4; }
     virtual inline int ExactNumTopBlobs() const { return 2; }
 
-  protected:
+   protected:
     virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
     virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
@@ -54,4 +54,4 @@ namespace caffe {
 
 }  // namespace caffe
 
-#endif  //CAFFE_BOX_ANNOTATOR_OHEM_LAYER_HPP_
+#endif  // CAFFE_BOX_ANNOTATOR_OHEM_LAYER_HPP_

--- a/include/caffe/layers/box_annotator_ohem_layer.hpp
+++ b/include/caffe/layers/box_annotator_ohem_layer.hpp
@@ -1,0 +1,57 @@
+#ifndef CAFFE_BOX_ANNOTATOR_OHEM_LAYER_HPP_
+#define CAFFE_BOX_ANNOTATOR_OHEM_LAYER_HPP_
+
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+#include "caffe/layers/loss_layer.hpp"
+
+namespace caffe {
+
+ /**
+ * @brief BoxAnnotatorOHEMLayer: Annotate box labels for Online Hard Example Mining (OHEM) training
+ * R-FCN
+ * Written by Yi Li
+ */
+  template <typename Dtype>
+  class BoxAnnotatorOHEMLayer :public Layer<Dtype>{
+  public:
+    explicit BoxAnnotatorOHEMLayer(const LayerParameter& param)
+      : Layer<Dtype>(param) {}
+    virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+    virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+    virtual inline const char* type() const { return "BoxAnnotatorOHEM"; }
+
+    virtual inline int ExactNumBottomBlobs() const { return 4; }
+    virtual inline int ExactNumTopBlobs() const { return 2; }
+
+  protected:
+    virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+    virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+    virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+    virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+
+    int num_;
+    int height_;
+    int width_;
+    int spatial_dim_;
+    int bbox_channels_;
+
+    int roi_per_img_;
+    int ignore_label_;
+  };
+
+}  // namespace caffe
+
+#endif  //CAFFE_BOX_ANNOTATOR_OHEM_LAYER_HPP_

--- a/include/caffe/layers/dropout_layer.hpp
+++ b/include/caffe/layers/dropout_layer.hpp
@@ -73,6 +73,7 @@ class DropoutLayer : public NeuronLayer<Dtype> {
   /// the scale for undropped inputs at train time @f$ 1 / (1 - p) @f$
   Dtype scale_;
   unsigned int uint_thres_;
+  bool scale_train_;
 };
 
 }  // namespace caffe

--- a/include/caffe/layers/psroi_pooling_layer.hpp
+++ b/include/caffe/layers/psroi_pooling_layer.hpp
@@ -13,7 +13,20 @@ namespace caffe {
 /** 
  * @brief Perform position-sensitive max pooling on regions of interest specified by input, takes
  *        as input N position-sensitive score maps and a list of R regions of interest.
- *
+ *   ROIPoolingLayer takes 2 inputs and produces 1 output. bottom[0] is
+ *   [N x (C x K^2) x H x W] position-sensitive score maps on which pooling is performed. bottom[1] is
+ *   [R x 5] containing a list R ROI tuples with batch index and coordinates of
+ *   regions of interest. Each row in bottom[1] is a ROI tuple in format
+ *   [batch_index x1 y1 x2 y2], where batch_index corresponds to the index of
+ *   instance in the first input and x1 y1 x2 y2 are 0-indexed coordinates
+ *   of ROI rectangle (including its boundaries). The output top[0] is [R x C x K x K] score maps pooled
+ *   within the ROI tuples.
+ * @param param provides PSROIPoolingParameter psroi_pooling_param,
+ *        with PSROIPoolingLayer options:
+ *  - output_dim. The pooled output channel number.
+ *  - group_size. The number of groups to encode position-sensitive score maps
+ *  - spatial_scale. Multiplicative spatial scale factor to translate ROI
+ *  coordinates from their input scale to the scale used when pooling.
  * R-FCN
  * Written by Yi Li
  */
@@ -21,43 +34,43 @@ namespace caffe {
 template <typename Dtype>
 class PSROIPoolingLayer : public Layer<Dtype> {
 public:
-	explicit PSROIPoolingLayer(const LayerParameter& param)
-		: Layer<Dtype>(param) {}
-	virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
-		const vector<Blob<Dtype>*>& top);
-	virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
-		const vector<Blob<Dtype>*>& top);
+  explicit PSROIPoolingLayer(const LayerParameter& param)
+    : Layer<Dtype>(param) {}
+  virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top);
+  virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top);
 
-	virtual inline const char* type() const { return "PSROIPooling"; }
+  virtual inline const char* type() const { return "PSROIPooling"; }
 
-	virtual inline int MinBottomBlobs() const { return 2; }
-	virtual inline int MaxBottomBlobs() const { return 2; }
-	virtual inline int MinTopBlobs() const { return 1; }
-	virtual inline int MaxTopBlobs() const { return 1; }
+  virtual inline int MinBottomBlobs() const { return 2; }
+  virtual inline int MaxBottomBlobs() const { return 2; }
+  virtual inline int MinTopBlobs() const { return 1; }
+  virtual inline int MaxTopBlobs() const { return 1; }
 
 protected:
-	virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
-		const vector<Blob<Dtype>*>& top);
-	virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
-		const vector<Blob<Dtype>*>& top);
-	virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
-		const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
-	virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
-		const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top);
+  virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top);
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+  virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
 
-	Dtype spatial_scale_;
-	int output_dim_;
-	int group_size_;
+  Dtype spatial_scale_;
+  int output_dim_;
+  int group_size_;
 
-	int channels_;
-	int height_;
-	int width_;
+  int channels_;
+  int height_;
+  int width_;
 
-	int pooled_height_;
-	int pooled_width_;
-	Blob<int> mapping_channel_;
+  int pooled_height_;
+  int pooled_width_;
+  Blob<int> mapping_channel_;
 };
 
 }  // namespace caffe
 
-#endif  // CAFFE_ROI_POOLING_LAYER_HPP_
+#endif  // CAFFE_PSROI_POOLING_LAYER_HPP_

--- a/include/caffe/layers/psroi_pooling_layer.hpp
+++ b/include/caffe/layers/psroi_pooling_layer.hpp
@@ -33,7 +33,7 @@ namespace caffe {
 
 template <typename Dtype>
 class PSROIPoolingLayer : public Layer<Dtype> {
-public:
+ public:
   explicit PSROIPoolingLayer(const LayerParameter& param)
     : Layer<Dtype>(param) {}
   virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
@@ -48,7 +48,7 @@ public:
   virtual inline int MinTopBlobs() const { return 1; }
   virtual inline int MaxTopBlobs() const { return 1; }
 
-protected:
+ protected:
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top);
   virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,

--- a/include/caffe/layers/psroi_pooling_layer.hpp
+++ b/include/caffe/layers/psroi_pooling_layer.hpp
@@ -1,0 +1,63 @@
+#ifndef CAFFE_PSROI_POOLING_LAYER_HPP_
+#define CAFFE_PSROI_POOLING_LAYER_HPP_
+
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+namespace caffe {
+
+/** 
+ * @brief Perform position-sensitive max pooling on regions of interest specified by input, takes
+ *        as input N position-sensitive score maps and a list of R regions of interest.
+ *
+ * R-FCN
+ * Written by Yi Li
+ */
+
+template <typename Dtype>
+class PSROIPoolingLayer : public Layer<Dtype> {
+public:
+	explicit PSROIPoolingLayer(const LayerParameter& param)
+		: Layer<Dtype>(param) {}
+	virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+		const vector<Blob<Dtype>*>& top);
+	virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+		const vector<Blob<Dtype>*>& top);
+
+	virtual inline const char* type() const { return "PSROIPooling"; }
+
+	virtual inline int MinBottomBlobs() const { return 2; }
+	virtual inline int MaxBottomBlobs() const { return 2; }
+	virtual inline int MinTopBlobs() const { return 1; }
+	virtual inline int MaxTopBlobs() const { return 1; }
+
+protected:
+	virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+		const vector<Blob<Dtype>*>& top);
+	virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+		const vector<Blob<Dtype>*>& top);
+	virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+		const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+	virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
+		const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+
+	Dtype spatial_scale_;
+	int output_dim_;
+	int group_size_;
+
+	int channels_;
+	int height_;
+	int width_;
+
+	int pooled_height_;
+	int pooled_width_;
+	Blob<int> mapping_channel_;
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_ROI_POOLING_LAYER_HPP_

--- a/include/caffe/layers/roi_pooling_layer.hpp
+++ b/include/caffe/layers/roi_pooling_layer.hpp
@@ -1,0 +1,58 @@
+#ifndef CAFFE_ROI_POOLING_LAYER_HPP_
+#define CAFFE_ROI_POOLING_LAYER_HPP_
+
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+namespace caffe {
+
+/**
+ * @brief ROIPoolingLayer - Region of Interest Pooling Layer.
+ *
+ * Fast R-CNN
+ * Written by Ross Girshick
+ */
+
+template <typename Dtype>
+class ROIPoolingLayer : public Layer<Dtype> {
+ public:
+  explicit ROIPoolingLayer(const LayerParameter& param)
+      : Layer<Dtype>(param) {}
+  virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+  virtual inline const char* type() const { return "ROIPooling"; }
+
+  virtual inline int MinBottomBlobs() const { return 2; }
+  virtual inline int MaxBottomBlobs() const { return 2; }
+  virtual inline int MinTopBlobs() const { return 1; }
+  virtual inline int MaxTopBlobs() const { return 1; }
+
+ protected:
+  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+  virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+
+  int channels_;
+  int height_;
+  int width_;
+  int pooled_height_;
+  int pooled_width_;
+  Dtype spatial_scale_;
+  Blob<int> max_idx_;
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_ROI_POOLING_LAYER_HPP_

--- a/include/caffe/layers/roi_pooling_layer.hpp
+++ b/include/caffe/layers/roi_pooling_layer.hpp
@@ -10,8 +10,34 @@
 
 namespace caffe {
 
-/**
- * @brief ROIPoolingLayer - Region of Interest Pooling Layer.
+/** 
+ * @brief Perform max pooling on regions of interest specified by input, takes
+ *        as input N feature maps and a list of R regions of interest.
+ *
+ *   ROIPoolingLayer takes 2 inputs and produces 1 output. bottom[0] is
+ *   [N x C x H x W] feature maps on which pooling is performed. bottom[1] is
+ *   [R x 5] containing a list R ROI tuples with batch index and coordinates of
+ *   regions of interest. Each row in bottom[1] is a ROI tuple in format
+ *   [batch_index x1 y1 x2 y2], where batch_index corresponds to the index of
+ *   instance in the first input and x1 y1 x2 y2 are 0-indexed coordinates
+ *   of ROI rectangle (including its boundaries).
+ *
+ *   For each of the R ROIs, max-pooling is performed over pooled_h x pooled_w
+ *   output bins (specified in roi_pooling_param). The pooling bin sizes are
+ *   adaptively set such that they tile ROI rectangle in the indexed feature
+ *   map. The pooling region of vertical bin ph in [0, pooled_h) is computed as
+ *
+ *    start_ph (included) = y1 + floor(ph * (y2 - y1 + 1) / pooled_h)
+ *    end_ph (excluded)   = y1 + ceil((ph + 1) * (y2 - y1 + 1) / pooled_h)
+ *
+ *   and similar horizontal bins.
+ *
+ * @param param provides ROIPoolingParameter roi_pooling_param,
+ *        with ROIPoolingLayer options:
+ *  - pooled_h. The pooled output height.
+ *  - pooled_w. The pooled output width
+ *  - spatial_scale. Multiplicative spatial scale factor to translate ROI
+ *  coordinates from their input scale to the scale used when pooling.
  *
  * Fast R-CNN
  * Written by Ross Girshick

--- a/include/caffe/layers/smooth_l1_loss_layer.hpp
+++ b/include/caffe/layers/smooth_l1_loss_layer.hpp
@@ -1,0 +1,65 @@
+#ifndef CAFFE_SMOOTH_L1_LOSS_LAYER_HPP_
+#define CAFFE_SMOOTH_L1_LOSS_LAYER_HPP_
+
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+#include "caffe/layers/loss_layer.hpp"
+
+namespace caffe {
+
+/**
+ * @brief SmoothL1LossLayer
+ *
+ * Fast R-CNN
+ * Written by Ross Girshick
+ */
+template <typename Dtype>
+class SmoothL1LossLayer : public LossLayer<Dtype> {
+ public:
+  explicit SmoothL1LossLayer(const LayerParameter& param)
+      : LossLayer<Dtype>(param), diff_() {}
+  virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+  virtual inline const char* type() const { return "SmoothL1Loss"; }
+
+  virtual inline int ExactNumBottomBlobs() const { return -1; }
+  virtual inline int MinBottomBlobs() const { return 2; }
+  virtual inline int MaxBottomBlobs() const { return 4; }
+
+  /**
+   * Unlike most loss layers, in the SmoothL1LossLayer we can backpropagate
+   * to both inputs -- override to return true and always allow force_backward.
+   */
+  virtual inline bool AllowForceBackward(const int bottom_index) const {
+    return true;
+  }
+
+ protected:
+  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+  virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+
+  Blob<Dtype> diff_;
+  Blob<Dtype> errors_;
+  Blob<Dtype> ones_;
+  bool has_weights_;
+  Dtype sigma2_;
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_SMOOTH_L1_LOSS_LAYER_HPP_

--- a/include/caffe/layers/smooth_l1_loss_ohem_layer.hpp
+++ b/include/caffe/layers/smooth_l1_loss_ohem_layer.hpp
@@ -18,58 +18,59 @@ namespace caffe {
  * R-FCN
  * Written by Yi Li
  */
-	template <typename Dtype>
-	class SmoothL1LossOHEMLayer : public LossLayer<Dtype> {
-	public:
-		explicit SmoothL1LossOHEMLayer(const LayerParameter& param)
-			: LossLayer<Dtype>(param), diff_() {}
-		virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
-			const vector<Blob<Dtype>*>& top);
-		virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
-			const vector<Blob<Dtype>*>& top);
+  template <typename Dtype>
+  class SmoothL1LossOHEMLayer : public LossLayer<Dtype> {
+   public:
+    explicit SmoothL1LossOHEMLayer(const LayerParameter& param)
+      : LossLayer<Dtype>(param), diff_() {}
+    virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+    virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
 
-		virtual inline const char* type() const { return "SmoothL1LossOHEM"; }
+    virtual inline const char* type() const { return "SmoothL1LossOHEM"; }
 
-		virtual inline int ExactNumBottomBlobs() const { return -1; }
-		virtual inline int MinBottomBlobs() const { return 2; }
-		virtual inline int MaxBottomBlobs() const { return 3; }
-		virtual inline int ExactNumTopBlobs() const { return -1; }
-		virtual inline int MinTopBlobs() const { return 1; }
-		virtual inline int MaxTopBlobs() const { return 2; }
+    virtual inline int ExactNumBottomBlobs() const { return -1; }
+    virtual inline int MinBottomBlobs() const { return 2; }
+    virtual inline int MaxBottomBlobs() const { return 3; }
+    virtual inline int ExactNumTopBlobs() const { return -1; }
+    virtual inline int MinTopBlobs() const { return 1; }
+    virtual inline int MaxTopBlobs() const { return 2; }
 
-		/**
-		* Unlike most loss layers, in the SmoothL1LossOHEMLayer we can backpropagate
-		* to both inputs -- override to return true and always allow force_backward.
-		*/
-		virtual inline bool AllowForceBackward(const int bottom_index) const {
-			return true;
-		}
+    /**
+    * Unlike most loss layers, in the SmoothL1LossOHEMLayer we can backpropagate
+    * to both inputs -- override to return true and always allow force_backward.
+    */
+    virtual inline bool AllowForceBackward(const int bottom_index) const {
+      return true;
+    }
 
-	protected:
-		virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
-			const vector<Blob<Dtype>*>& top);
-		virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
-			const vector<Blob<Dtype>*>& top);
+   protected:
+    virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+    virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
 
-		virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
-			const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
-		virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
-			const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+    virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+    virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
 
-		/// Read the normalization mode parameter and compute the normalizer based
-		/// on the blob size. 
-		virtual Dtype get_normalizer(
-			LossParameter_NormalizationMode normalization_mode, Dtype pre_fixed_normalizer);
+    /// Read the normalization mode parameter and compute the normalizer based
+    /// on the blob size.
+    virtual Dtype get_normalizer(
+      LossParameter_NormalizationMode normalization_mode,
+      Dtype pre_fixed_normalizer);
 
-		Blob<Dtype> diff_;
-		Blob<Dtype> errors_;
-		bool has_weights_;
+    Blob<Dtype> diff_;
+    Blob<Dtype> errors_;
+    bool has_weights_;
 
-		int outer_num_, inner_num_;
+    int outer_num_, inner_num_;
 
-		/// How to normalize the output loss.
-		LossParameter_NormalizationMode normalization_;
-	};
+    /// How to normalize the output loss.
+    LossParameter_NormalizationMode normalization_;
+  };
 
 }  // namespace caffe
 

--- a/include/caffe/layers/smooth_l1_loss_ohem_layer.hpp
+++ b/include/caffe/layers/smooth_l1_loss_ohem_layer.hpp
@@ -1,0 +1,76 @@
+#ifndef CAFFE_SMOOTH_L1_LOSS_OHEM_LAYER_HPP_
+#define CAFFE_SMOOTH_L1_LOSS_OHEM_LAYER_HPP_
+
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+#include "caffe/layers/loss_layer.hpp"
+
+namespace caffe {
+
+/**
+ * @brief SmoothL1LossOHEMLayer
+ *
+ * R-FCN
+ * Written by Yi Li
+ */
+	template <typename Dtype>
+	class SmoothL1LossOHEMLayer : public LossLayer<Dtype> {
+	public:
+		explicit SmoothL1LossOHEMLayer(const LayerParameter& param)
+			: LossLayer<Dtype>(param), diff_() {}
+		virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+			const vector<Blob<Dtype>*>& top);
+		virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+			const vector<Blob<Dtype>*>& top);
+
+		virtual inline const char* type() const { return "SmoothL1LossOHEM"; }
+
+		virtual inline int ExactNumBottomBlobs() const { return -1; }
+		virtual inline int MinBottomBlobs() const { return 2; }
+		virtual inline int MaxBottomBlobs() const { return 3; }
+		virtual inline int ExactNumTopBlobs() const { return -1; }
+		virtual inline int MinTopBlobs() const { return 1; }
+		virtual inline int MaxTopBlobs() const { return 2; }
+
+		/**
+		* Unlike most loss layers, in the SmoothL1LossOHEMLayer we can backpropagate
+		* to both inputs -- override to return true and always allow force_backward.
+		*/
+		virtual inline bool AllowForceBackward(const int bottom_index) const {
+			return true;
+		}
+
+	protected:
+		virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+			const vector<Blob<Dtype>*>& top);
+		virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+			const vector<Blob<Dtype>*>& top);
+
+		virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+			const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+		virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
+			const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+
+		/// Read the normalization mode parameter and compute the normalizer based
+		/// on the blob size. 
+		virtual Dtype get_normalizer(
+			LossParameter_NormalizationMode normalization_mode, Dtype pre_fixed_normalizer);
+
+		Blob<Dtype> diff_;
+		Blob<Dtype> errors_;
+		bool has_weights_;
+
+		int outer_num_, inner_num_;
+
+		/// How to normalize the output loss.
+		LossParameter_NormalizationMode normalization_;
+	};
+
+}  // namespace caffe
+
+#endif  // CAFFE_SMOOTH_L1_LOSS_OHEM_LAYER_HPP_

--- a/include/caffe/layers/softmax_loss_ohem_layer.hpp
+++ b/include/caffe/layers/softmax_loss_ohem_layer.hpp
@@ -60,7 +60,7 @@ class SoftmaxWithLossOHEMLayer : public LossLayer<Dtype> {
   virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
 
-  virtual inline const char* type() const { return "SoftmaxWithLoss"; }
+  virtual inline const char* type() const { return "SoftmaxWithLossOHEM"; }
   virtual inline int ExactNumTopBlobs() const { return -1; }
   virtual inline int MinTopBlobs() const { return 1; }
   virtual inline int MaxTopBlobs() const { return 3; }

--- a/include/caffe/layers/softmax_loss_ohem_layer.hpp
+++ b/include/caffe/layers/softmax_loss_ohem_layer.hpp
@@ -1,0 +1,132 @@
+#ifndef CAFFE_SOFTMAX_WITH_LOSS_OHEM_LAYER_HPP_
+#define CAFFE_SOFTMAX_WITH_LOSS_OHEM_LAYER_HPP_
+
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+#include "caffe/layers/loss_layer.hpp"
+#include "caffe/layers/softmax_layer.hpp"
+
+namespace caffe {
+
+/**
+ * @brief Computes the multinomial logistic loss for a one-of-many
+ *        classification task, passing real-valued predictions through a
+ *        softmax to get a probability distribution over classes.
+ *        An additional per-instance loss is produced in output for OHEM 
+ *
+ * This layer should be preferred over separate
+ * SoftmaxLayer + MultinomialLogisticLossLayer
+ * as its gradient computation is more numerically stable.
+ * At test time, this layer can be replaced simply by a SoftmaxLayer.
+ *
+ * @param bottom input Blob vector (length 2)
+ *   -# @f$ (N \times C \times H \times W) @f$
+ *      the predictions @f$ x @f$, a Blob with values in
+ *      @f$ [-\infty, +\infty] @f$ indicating the predicted score for each of
+ *      the @f$ K = CHW @f$ classes. This layer maps these scores to a
+ *      probability distribution over classes using the softmax function
+ *      @f$ \hat{p}_{nk} = \exp(x_{nk}) /
+ *      \left[\sum_{k'} \exp(x_{nk'})\right] @f$ (see SoftmaxLayer).
+ *   -# @f$ (N \times 1 \times 1 \times 1) @f$
+ *      the labels @f$ l @f$, an integer-valued Blob with values
+ *      @f$ l_n \in [0, 1, 2, ..., K - 1] @f$
+ *      indicating the correct class label among the @f$ K @f$ classes
+ * @param top output Blob vector (length 1)
+ *   -# @f$ (1 \times 1 \times 1 \times 1) @f$
+ *      the computed cross-entropy classification loss: @f$ E =
+ *        \frac{-1}{N} \sum\limits_{n=1}^N \log(\hat{p}_{n,l_n})
+ *      @f$, for softmax output class probabilites @f$ \hat{p} @f$
+ *      @f$, per-instance cross-entropy classification loss
+ */
+template <typename Dtype>
+class SoftmaxWithLossOHEMLayer : public LossLayer<Dtype> {
+ public:
+   /**
+    * @param param provides LossParameter loss_param, with options:
+    *  - ignore_label (optional)
+    *    Specify a label value that should be ignored when computing the loss.
+    *  - normalize (optional, default true)
+    *    If true, the loss is normalized by the number of (nonignored) labels
+    *    present; otherwise the loss is simply summed over spatial locations.
+    */
+  explicit SoftmaxWithLossOHEMLayer(const LayerParameter& param)
+      : LossLayer<Dtype>(param) {}
+  virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+  virtual inline const char* type() const { return "SoftmaxWithLoss"; }
+  virtual inline int ExactNumTopBlobs() const { return -1; }
+  virtual inline int MinTopBlobs() const { return 1; }
+  virtual inline int MaxTopBlobs() const { return 3; }
+
+ protected:
+  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  /**
+   * @brief Computes the softmax loss error gradient w.r.t. the predictions.
+   *
+   * Gradients cannot be computed with respect to the label inputs (bottom[1]),
+   * so this method ignores bottom[1] and requires !propagate_down[1], crashing
+   * if propagate_down[1] is set.
+   *
+   * @param top output Blob vector (length 1), providing the error gradient with
+   *      respect to the outputs
+   *   -# @f$ (1 \times 1 \times 1 \times 1) @f$
+   *      This Blob's diff will simply contain the loss_weight* @f$ \lambda @f$,
+   *      as @f$ \lambda @f$ is the coefficient of this layer's output
+   *      @f$\ell_i@f$ in the overall Net loss
+   *      @f$ E = \lambda_i \ell_i + \mbox{other loss terms}@f$; hence
+   *      @f$ \frac{\partial E}{\partial \ell_i} = \lambda_i @f$.
+   *      (*Assuming that this top Blob is not used as a bottom (input) by any
+   *      other layer of the Net.)
+   * @param propagate_down see Layer::Backward.
+   *      propagate_down[1] must be false as we can't compute gradients with
+   *      respect to the labels.
+   * @param bottom input Blob vector (length 2)
+   *   -# @f$ (N \times C \times H \times W) @f$
+   *      the predictions @f$ x @f$; Backward computes diff
+   *      @f$ \frac{\partial E}{\partial x} @f$
+   *   -# @f$ (N \times 1 \times 1 \times 1) @f$
+   *      the labels -- ignored as we can't compute their error gradients
+   */
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+  virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+
+  /// Read the normalization mode parameter and compute the normalizer based
+  /// on the blob size.  If normalization_mode is VALID, the count of valid
+  /// outputs will be read from valid_count, unless it is -1 in which case
+  /// all outputs are assumed to be valid.
+  virtual Dtype get_normalizer(
+      LossParameter_NormalizationMode normalization_mode, int valid_count);
+
+  /// The internal SoftmaxLayer used to map predictions to a distribution.
+  shared_ptr<Layer<Dtype> > softmax_layer_;
+  /// prob stores the output probability predictions from the SoftmaxLayer.
+  Blob<Dtype> prob_;
+  /// bottom vector holder used in call to the underlying SoftmaxLayer::Forward
+  vector<Blob<Dtype>*> softmax_bottom_vec_;
+  /// top vector holder used in call to the underlying SoftmaxLayer::Forward
+  vector<Blob<Dtype>*> softmax_top_vec_;
+  /// Whether to ignore instances with a certain label.
+  bool has_ignore_label_;
+  /// The label indicating that an instance should be ignored.
+  int ignore_label_;
+  /// How to normalize the output loss.
+  LossParameter_NormalizationMode normalization_;
+
+  int softmax_axis_, outer_num_, inner_num_;
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_SOFTMAX_WITH_LOSS_OHEM_LAYER_HPP_

--- a/include/caffe/net.hpp
+++ b/include/caffe/net.hpp
@@ -31,6 +31,10 @@ class Net {
   /// @brief Initialize a network with a NetParameter.
   void Init(const NetParameter& param);
 
+  /// @brief set phase
+  /// enable train and test with one network, for saving memory
+  void SetPhase(Phase phase);
+
   /**
    * @brief Run Forward and return the result.
    *
@@ -149,6 +153,14 @@ class Net {
   inline const vector<vector<Blob<Dtype>*> >& top_vecs() const {
     return top_vecs_;
   }
+  
+  inline const vector<vector<int> >& bottom_id_vecs() const {
+    return bottom_id_vecs_;
+  }
+  inline const vector<vector<int> >& top_id_vecs() const {
+    return top_id_vecs_;
+  }
+
   /// @brief returns the ids of the top blobs of layer i
   inline const vector<int> & top_ids(int i) const {
     CHECK_GE(i, 0) << "Invalid layer id";

--- a/include/caffe/net.hpp
+++ b/include/caffe/net.hpp
@@ -153,7 +153,7 @@ class Net {
   inline const vector<vector<Blob<Dtype>*> >& top_vecs() const {
     return top_vecs_;
   }
-  
+
   inline const vector<vector<int> >& bottom_id_vecs() const {
     return bottom_id_vecs_;
   }

--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -72,7 +72,9 @@ class Solver {
   inline const vector<shared_ptr<Net<Dtype> > >& test_nets() {
     return test_nets_;
   }
-  int iter() const { return iter_; }
+  
+  int iter() { return iter_; }
+  int max_iter() const { return param_.max_iter(); }
 
   // Invoked at specific points during an iteration
   class Callback {

--- a/matlab/+caffe/Blob.m
+++ b/matlab/+caffe/Blob.m
@@ -33,6 +33,9 @@ classdef Blob < handle
       diff = self.check_and_preprocess_data(diff);
       caffe_('blob_set_diff', self.hBlob_self, diff);
     end
+    function copy_data_from(self, blob)
+      caffe_('blob_copy_data', self.hBlob_self, blob.hBlob_self);  
+    end
   end
   
   methods (Access = private)

--- a/matlab/+caffe/Layer.m
+++ b/matlab/+caffe/Layer.m
@@ -25,6 +25,9 @@ classdef Layer < handle
         self.params(n) = caffe.Blob(self.attributes.hBlob_blobs(n));
       end
     end
+    function set_params_data(self, blob_index, params) 
+      caffe.Blob(self.attributes.hBlob_blobs(blob_index)).set_data(params); 
+    end
     function layer_type = type(self)
       layer_type = caffe_('layer_get_type', self.hLayer_self);
     end

--- a/matlab/+caffe/Net.m
+++ b/matlab/+caffe/Net.m
@@ -21,6 +21,8 @@ classdef Net < handle
     name2blob_index
     layer_names
     blob_names
+    bottom_id_vecs
+    top_id_vecs
   end
   
   methods
@@ -67,6 +69,23 @@ classdef Net < handle
       % expose layer_names and blob_names for public read access
       self.layer_names = self.attributes.layer_names;
       self.blob_names = self.attributes.blob_names;
+            
+      % expose bottom_id_vecs and top_id_vecs for public read access
+      self.attributes.bottom_id_vecs = cellfun(@(x) x+1, self.attributes.bottom_id_vecs, 'UniformOutput', false);
+      self.bottom_id_vecs = self.attributes.bottom_id_vecs;
+      self.attributes.top_id_vecs = cellfun(@(x) x+1, self.attributes.top_id_vecs, 'UniformOutput', false);
+      self.top_id_vecs = self.attributes.top_id_vecs;
+    end
+    function set_phase(self, phase_name)
+      CHECK(ischar(phase_name), 'phase_name must be a string');
+      CHECK(strcmp(phase_name, 'train') || strcmp(phase_name, 'test'), ...
+            sprintf('phase_name can only be %strain%s or %stest%s', ...
+            char(39), char(39), char(39), char(39)));
+      caffe_('net_set_phase', self.hNet_self, phase_name);
+    end
+    function share_weights_with(self, net)
+      CHECK(is_valid_handle(net.hNet_net), 'invalid Net handle');
+      caffe_('net_share_trained_layers_with', self.hNet_net, net.hNet_net);
     end
     function delete (self)
       caffe_('delete_net', self.hNet_self);
@@ -84,11 +103,33 @@ classdef Net < handle
       CHECK(isscalar(blob_index), 'blob_index must be a scalar');
       blob = self.layer_vec(self.name2layer_index(layer_name)).params(blob_index);
     end
+    function set_params_data(self, layer_name, blob_index, data)
+      CHECK(ischar(layer_name), 'layer_name must be a string');
+      CHECK(isscalar(blob_index), 'blob_index must be a scalar');
+      self.layer_vec(self.name2layer_index(layer_name)).set_params_data(blob_index, data);
+    end
     function forward_prefilled(self)
       caffe_('net_forward', self.hNet_self);
     end
     function backward_prefilled(self)
       caffe_('net_backward', self.hNet_self);
+    end
+    function set_input_data(self, input_data)
+      CHECK(iscell(input_data), 'input_data must be a cell array');
+      CHECK(length(input_data) == length(self.inputs), ...
+        'input data cell length must match input blob number');
+      % copy data to input blobs
+      for n = 1:length(self.inputs)
+        self.blobs(self.inputs{n}).set_data(input_data{n});
+      end
+    end
+    function res = get_output(self)
+      % get onput blobs
+      res = struct('blob_name', '', 'data', []);
+      for n = 1:length(self.outputs)
+        res(n).blob_name = self.outputs{n};
+        res(n).data = self.blobs(self.outputs{n}).get_data();
+      end
     end
     function res = forward(self, input_data)
       CHECK(iscell(input_data), 'input_data must be a cell array');
@@ -96,6 +137,9 @@ classdef Net < handle
         'input data cell length must match input blob number');
       % copy data to input blobs
       for n = 1:length(self.inputs)
+        if isempty(input_data{n})
+          continue;
+        end
         self.blobs(self.inputs{n}).set_data(input_data{n});
       end
       self.forward_prefilled();
@@ -127,6 +171,21 @@ classdef Net < handle
     end
     function reshape(self)
       caffe_('net_reshape', self.hNet_self);
+    end
+    function reshape_as_input(self, input_data)
+      CHECK(iscell(input_data), 'input_data must be a cell array');
+      CHECK(length(input_data) == length(self.inputs), ...
+        'input data cell length must match input blob number');
+      % reshape input blobs
+      for n = 1:length(self.inputs)
+        if isempty(input_data{n})
+            continue;
+        end
+        input_data_size = size(input_data{n});
+        input_data_size_extended = [input_data_size, ones(1, 4 - length(input_data_size))];
+        self.blobs(self.inputs{n}).reshape(input_data_size_extended);
+      end
+      self.reshape();
     end
     function save(self, weights_file)
       CHECK(ischar(weights_file), 'weights_file must be a string');

--- a/matlab/+caffe/Solver.m
+++ b/matlab/+caffe/Solver.m
@@ -42,6 +42,9 @@ classdef Solver < handle
     function iter = iter(self)
       iter = caffe_('solver_get_iter', self.hSolver_self);
     end
+    function max_iter = max_iter(self)
+      max_iter = caffe_('solver_get_max_iter', self.hSolver_self);
+    end
     function restore(self, snapshot_filename)
       CHECK(ischar(snapshot_filename), 'snapshot_filename must be a string');
       CHECK_FILE_EXIST(snapshot_filename);

--- a/matlab/+caffe/init_log.m
+++ b/matlab/+caffe/init_log.m
@@ -1,0 +1,15 @@
+function init_log(log_base_filename)
+% init_log(log_base_filename)
+%   init Caffe's log
+
+CHECK(ischar(log_base_filename) && ~isempty(log_base_filename), ...
+  'log_base_filename must be string');
+
+[log_base_dir] = fileparts(log_base_filename);
+if ~exist(log_base_dir, 'dir')
+    mkdir(log_base_dir);
+end
+
+caffe_('init_log', log_base_filename);
+
+end

--- a/matlab/+caffe/private/caffe_.cpp
+++ b/matlab/+caffe/private/caffe_.cpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "mex.h"
+#include "gpu/mxGPUArray.h"
 
 #include "caffe/caffe.hpp"
 
@@ -56,9 +57,21 @@ enum WhichMemory { DATA, DIFF };
 // Copy matlab array to Blob data or diff
 static void mx_mat_to_blob(const mxArray* mx_mat, Blob<float>* blob,
     WhichMemory data_or_diff) {
-  mxCHECK(blob->count() == mxGetNumberOfElements(mx_mat),
+
+  const float* mat_mem_ptr = NULL;
+  mxGPUArray const *mx_mat_gpu;
+  if (mxIsGPUArray(mx_mat)){
+    mxInitGPU();
+    mx_mat_gpu = mxGPUCreateFromMxArray(mx_mat);
+    mat_mem_ptr = reinterpret_cast<const float*>(mxGPUGetDataReadOnly(mx_mat_gpu));
+    mxCHECK(blob->count() == mxGPUGetNumberOfElements(mx_mat_gpu),
       "number of elements in target blob doesn't match that in input mxArray");
-  const float* mat_mem_ptr = reinterpret_cast<const float*>(mxGetData(mx_mat));
+  }
+  else{
+    mxCHECK(blob->count() == mxGetNumberOfElements(mx_mat),
+      "number of elements in target blob doesn't match that in input mxArray");
+    mat_mem_ptr = reinterpret_cast<const float*>(mxGetData(mx_mat));
+  }
   float* blob_mem_ptr = NULL;
   switch (Caffe::mode()) {
   case Caffe::CPU:
@@ -73,6 +86,10 @@ static void mx_mat_to_blob(const mxArray* mx_mat, Blob<float>* blob,
     mxERROR("Unknown Caffe mode");
   }
   caffe_copy(blob->count(), mat_mem_ptr, blob_mem_ptr);
+
+  if (mxIsGPUArray(mx_mat)){
+    mxGPUDestroyGPUArray(mx_mat_gpu);
+  }
 }
 
 // Copy Blob data or diff to matlab array
@@ -114,6 +131,16 @@ static mxArray* int_vec_to_mx_vec(const vector<int>& int_vec) {
     vec_mem_ptr[i] = static_cast<double>(int_vec[i]);
   }
   return mx_vec;
+}
+
+
+// Convert vector<vector<int> > to matlab cell of (row vector)s
+static mxArray* int_vec_vec_to_mx_cell_vec(const vector<vector<int> >& int_vec_vec) {
+  mxArray* mx_cell_vec = mxCreateCellMatrix(int_vec_vec.size(), 1);
+  for (int i = 0; i < int_vec_vec.size(); i++){
+    mxSetCell(mx_cell_vec, i, int_vec_to_mx_vec(int_vec_vec[i]));
+  }
+  return mx_cell_vec;
 }
 
 // Convert vector<string> to matlab cell vector of strings
@@ -232,6 +259,14 @@ static void solver_get_iter(MEX_ARGS) {
   plhs[0] = mxCreateDoubleScalar(solver->iter());
 }
 
+// Usage: caffe_('solver_get_max_iter', hSolver)
+static void solver_get_max_iter(MEX_ARGS) {
+  mxCHECK(nrhs == 1 && mxIsStruct(prhs[0]),
+    "Usage: caffe_('solver_get_max_iter', hSolver)");
+  Solver<float>* solver = handle_to_ptr<Solver<float> >(prhs[0]);
+  plhs[0] = mxCreateDoubleScalar(solver->max_iter());
+}
+
 // Usage: caffe_('solver_restore', hSolver, snapshot_file)
 static void solver_restore(MEX_ARGS) {
   mxCHECK(nrhs == 2 && mxIsStruct(prhs[0]) && mxIsChar(prhs[1]),
@@ -293,14 +328,34 @@ static void delete_net(MEX_ARGS) {
   }), nets_.end());
 }
 
+// Usage: caffe_('net_set_phase', hNet, phase_name)
+static void net_set_phase(MEX_ARGS) {
+  mxCHECK(nrhs == 2 && mxIsStruct(prhs[0]) && mxIsChar(prhs[1]),
+    "Usage: caffe_('net_set_phase', hNet, phase_name)");
+  Net<float>* net = handle_to_ptr<Net<float> >(prhs[0]);
+  char* phase_name = mxArrayToString(prhs[1]);
+  Phase phase;
+  if (strcmp(phase_name, "train") == 0) {
+    phase = TRAIN;
+  }
+  else if (strcmp(phase_name, "test") == 0) {
+    phase = TEST;
+  }
+  else {
+    mxERROR("Unknown phase");
+  }
+  net->SetPhase(phase);
+  mxFree(phase_name);
+}
+
 // Usage: caffe_('net_get_attr', hNet)
 static void net_get_attr(MEX_ARGS) {
   mxCHECK(nrhs == 1 && mxIsStruct(prhs[0]),
       "Usage: caffe_('net_get_attr', hNet)");
   Net<float>* net = handle_to_ptr<Net<float> >(prhs[0]);
-  const int net_attr_num = 6;
+  const int net_attr_num = 8;
   const char* net_attrs[net_attr_num] = { "hLayer_layers", "hBlob_blobs",
-      "input_blob_indices", "output_blob_indices", "layer_names", "blob_names"};
+    "input_blob_indices", "output_blob_indices", "layer_names", "blob_names", "bottom_id_vecs", "top_id_vecs" };
   mxArray* mx_net_attr = mxCreateStructMatrix(1, 1, net_attr_num,
       net_attrs);
   mxSetField(mx_net_attr, 0, "hLayer_layers",
@@ -315,6 +370,10 @@ static void net_get_attr(MEX_ARGS) {
       str_vec_to_mx_strcell(net->layer_names()));
   mxSetField(mx_net_attr, 0, "blob_names",
       str_vec_to_mx_strcell(net->blob_names()));
+  mxSetField(mx_net_attr, 0, "bottom_id_vecs",
+    int_vec_vec_to_mx_cell_vec(net->bottom_id_vecs()));
+  mxSetField(mx_net_attr, 0, "top_id_vecs",
+    int_vec_vec_to_mx_cell_vec(net->top_id_vecs()));
   plhs[0] = mx_net_attr;
 }
 
@@ -343,6 +402,15 @@ static void net_copy_from(MEX_ARGS) {
   mxCHECK_FILE_EXIST(weights_file);
   net->CopyTrainedLayersFrom(weights_file);
   mxFree(weights_file);
+}
+
+// Usage: caffe_('net_shared_with', hNet, hNet_trained)
+static void net_share_trained_layers_with(MEX_ARGS) {
+  mxCHECK(nrhs == 2 && mxIsStruct(prhs[0]) && mxIsStruct(prhs[1]),
+    "Usage: caffe_('net_shared_with', hNet, hNet_trained)");
+  Net<float>* net = handle_to_ptr<Net<float> >(prhs[0]);
+  Net<float>* net_trained = handle_to_ptr<Net<float> >(prhs[1]);
+  net->ShareTrainedLayersWith(net_trained);
 }
 
 // Usage: caffe_('net_reshape', hNet)
@@ -428,10 +496,22 @@ static void blob_get_data(MEX_ARGS) {
 
 // Usage: caffe_('blob_set_data', hBlob, new_data)
 static void blob_set_data(MEX_ARGS) {
-  mxCHECK(nrhs == 2 && mxIsStruct(prhs[0]) && mxIsSingle(prhs[1]),
+  mxCHECK(nrhs == 2 && mxIsStruct(prhs[0]) && (mxIsSingle(prhs[1]) || mxIsGPUArray(prhs[1])),
       "Usage: caffe_('blob_set_data', hBlob, new_data)");
   Blob<float>* blob = handle_to_ptr<Blob<float> >(prhs[0]);
   mx_mat_to_blob(prhs[1], blob, DATA);
+}
+
+// Usage: caffe_('blob_copy_data', hBlob_to, hBlob_from)
+static void blob_copy_data(MEX_ARGS) {
+  mxCHECK(nrhs == 2 && mxIsStruct(prhs[0]) && mxIsStruct(prhs[1]),
+    "Usage: caffe_('blob_copy_data', hBlob_to, hBlob_from)");
+  Blob<float>* blob_to = handle_to_ptr<Blob<float> >(prhs[0]);
+  Blob<float>* blob_from = handle_to_ptr<Blob<float> >(prhs[1]);
+  //mxCHECK(blob_from->count() == blob_to->count(),
+  //	"number of elements in target blob doesn't match that in source blob");
+  
+  blob_to->CopyFrom(*blob_from, false, true); 
 }
 
 // Usage: caffe_('blob_get_diff', hBlob)
@@ -486,6 +566,54 @@ static void reset(MEX_ARGS) {
   nets_.clear();
   // Generate new init_key, so that handles created before becomes invalid
   init_key = static_cast<double>(caffe_rng_rand());
+}
+
+// Usage: caffe_('set_random_seed', random_seed)
+static void set_random_seed(MEX_ARGS) {
+  mxCHECK(nrhs == 1 && mxIsDouble(prhs[0]),
+    "Usage: caffe_('set_random_seed', random_seed)");
+  int random_seed = static_cast<unsigned int>(mxGetScalar(prhs[0]));
+  Caffe::set_random_seed(random_seed);
+}
+
+static void glog_failure_handler(){
+  static bool is_glog_failure = false;
+  if (!is_glog_failure)
+  {
+    is_glog_failure = true;
+    ::google::FlushLogFiles(0);
+    mexErrMsgTxt("glog check error, please check log and clear mex");
+  }
+}
+
+static void protobuf_log_handler(::google::protobuf::LogLevel level, const char* filename, int line,
+  const std::string& message)
+{
+  const int max_err_length = 512;
+  char err_message[max_err_length];
+  snprintf(err_message, max_err_length, "Protobuf : %s . at %s Line %d",
+           message.c_str(), filename, line);
+  LOG(INFO) << err_message;
+  ::google::FlushLogFiles(0);
+  mexErrMsgTxt(err_message);
+}
+
+// Usage: caffe_('init_log', log_base_filename)
+static void init_log(MEX_ARGS) {
+  static bool is_log_inited = false;
+
+  mxCHECK(nrhs == 1 && mxIsChar(prhs[0]),
+    "Usage: caffe_('init_log', log_dir)");
+  if (is_log_inited)
+    ::google::ShutdownGoogleLogging();
+  char* log_base_filename = mxArrayToString(prhs[0]);
+  ::google::SetLogDestination(0, log_base_filename);
+  mxFree(log_base_filename);
+  ::google::protobuf::SetLogHandler(&protobuf_log_handler);
+  ::google::InitGoogleLogging("caffe_mex");
+  ::google::InstallFailureFunction(&glog_failure_handler);
+
+  is_log_inited = true;
 }
 
 // Usage: caffe_('read_mean', mean_proto_file)
@@ -543,39 +671,43 @@ struct handler_registry {
 
 static handler_registry handlers[] = {
   // Public API functions
-  { "get_solver",         get_solver      },
-  { "delete_solver",      delete_solver   },
-  { "solver_get_attr",    solver_get_attr },
-  { "solver_get_iter",    solver_get_iter },
-  { "solver_restore",     solver_restore  },
-  { "solver_solve",       solver_solve    },
-  { "solver_step",        solver_step     },
-  { "get_net",            get_net         },
-  { "delete_net",         delete_net      },
-  { "net_get_attr",       net_get_attr    },
-  { "net_forward",        net_forward     },
-  { "net_backward",       net_backward    },
-  { "net_copy_from",      net_copy_from   },
-  { "net_reshape",        net_reshape     },
-  { "net_save",           net_save        },
-  { "layer_get_attr",     layer_get_attr  },
-  { "layer_get_type",     layer_get_type  },
-  { "blob_get_shape",     blob_get_shape  },
-  { "blob_reshape",       blob_reshape    },
-  { "blob_get_data",      blob_get_data   },
-  { "blob_set_data",      blob_set_data   },
-  { "blob_get_diff",      blob_get_diff   },
-  { "blob_set_diff",      blob_set_diff   },
-  { "set_mode_cpu",       set_mode_cpu    },
-  { "set_mode_gpu",       set_mode_gpu    },
-  { "set_device",         set_device      },
-  { "get_init_key",       get_init_key    },
-  { "reset",              reset           },
-  { "read_mean",          read_mean       },
-  { "write_mean",         write_mean      },
-  { "version",            version         },
+  { "get_solver",                    get_solver                     },
+  { "solver_get_attr",               solver_get_attr                },
+  { "solver_get_iter",               solver_get_iter                },
+  { "solver_get_max_iter",           solver_get_max_iter            },
+  { "solver_restore",                solver_restore                 },
+  { "solver_solve",                  solver_solve                   },
+  { "solver_step",                   solver_step                    },
+  { "get_net",                       get_net                        },
+  { "net_get_attr",                  net_get_attr                   },
+  { "net_set_phase",                 net_set_phase                  },
+  { "net_forward",                   net_forward                    },
+  { "net_backward",                  net_backward                   },
+  { "net_copy_from",                 net_copy_from                  },
+  { "net_share_trained_layers_with", net_share_trained_layers_with  },
+  { "net_reshape",                   net_reshape                    },
+  { "net_save",                      net_save                       },
+  { "layer_get_attr",                layer_get_attr                 },
+  { "layer_get_type",                layer_get_type                 },
+  { "blob_get_shape",                blob_get_shape                 },
+  { "blob_reshape",                  blob_reshape                   },
+  { "blob_get_data",                 blob_get_data                  },
+  { "blob_set_data",                 blob_set_data                  },
+  { "blob_copy_data",                blob_copy_data                 },
+  { "blob_get_diff",                 blob_get_diff                  },
+  { "blob_set_diff",                 blob_set_diff                  },
+  { "set_mode_cpu",                  set_mode_cpu                   },
+  { "set_mode_gpu",                  set_mode_gpu                   },
+  { "set_device",                    set_device                     },
+  { "set_random_seed",               set_random_seed                },
+  { "get_init_key",                  get_init_key                   },
+  { "init_log",                      init_log                       },
+  { "reset",                         reset                          },
+  { "read_mean",                     read_mean                      },
+  { "write_mean",                    write_mean                     },
+  { "version",                       version                        },
   // The end.
-  { "END",                NULL            },
+  { "END",                           NULL                           },
 };
 
 /** -----------------------------------------------------------------

--- a/matlab/+caffe/private/caffe_.cpp
+++ b/matlab/+caffe/private/caffe_.cpp
@@ -13,8 +13,8 @@
 #include <string>
 #include <vector>
 
-#include "mex.h"
 #include "gpu/mxGPUArray.h"
+#include "mex.h"
 
 #include "caffe/caffe.hpp"
 
@@ -60,14 +60,14 @@ static void mx_mat_to_blob(const mxArray* mx_mat, Blob<float>* blob,
 
   const float* mat_mem_ptr = NULL;
   mxGPUArray const *mx_mat_gpu;
-  if (mxIsGPUArray(mx_mat)){
+  if (mxIsGPUArray(mx_mat)) {
     mxInitGPU();
     mx_mat_gpu = mxGPUCreateFromMxArray(mx_mat);
-    mat_mem_ptr = reinterpret_cast<const float*>(mxGPUGetDataReadOnly(mx_mat_gpu));
+    mat_mem_ptr = reinterpret_cast<const float*>(
+      mxGPUGetDataReadOnly(mx_mat_gpu));
     mxCHECK(blob->count() == mxGPUGetNumberOfElements(mx_mat_gpu),
       "number of elements in target blob doesn't match that in input mxArray");
-  }
-  else{
+  } else {
     mxCHECK(blob->count() == mxGetNumberOfElements(mx_mat),
       "number of elements in target blob doesn't match that in input mxArray");
     mat_mem_ptr = reinterpret_cast<const float*>(mxGetData(mx_mat));
@@ -87,7 +87,7 @@ static void mx_mat_to_blob(const mxArray* mx_mat, Blob<float>* blob,
   }
   caffe_copy(blob->count(), mat_mem_ptr, blob_mem_ptr);
 
-  if (mxIsGPUArray(mx_mat)){
+  if (mxIsGPUArray(mx_mat)) {
     mxGPUDestroyGPUArray(mx_mat_gpu);
   }
 }
@@ -135,9 +135,10 @@ static mxArray* int_vec_to_mx_vec(const vector<int>& int_vec) {
 
 
 // Convert vector<vector<int> > to matlab cell of (row vector)s
-static mxArray* int_vec_vec_to_mx_cell_vec(const vector<vector<int> >& int_vec_vec) {
+static mxArray* int_vec_vec_to_mx_cell_vec(
+  const vector<vector<int> >& int_vec_vec) {
   mxArray* mx_cell_vec = mxCreateCellMatrix(int_vec_vec.size(), 1);
-  for (int i = 0; i < int_vec_vec.size(); i++){
+  for (int i = 0; i < int_vec_vec.size(); i++) {
     mxSetCell(mx_cell_vec, i, int_vec_to_mx_vec(int_vec_vec[i]));
   }
   return mx_cell_vec;
@@ -337,11 +338,9 @@ static void net_set_phase(MEX_ARGS) {
   Phase phase;
   if (strcmp(phase_name, "train") == 0) {
     phase = TRAIN;
-  }
-  else if (strcmp(phase_name, "test") == 0) {
+  } else if (strcmp(phase_name, "test") == 0) {
     phase = TEST;
-  }
-  else {
+  } else {
     mxERROR("Unknown phase");
   }
   net->SetPhase(phase);
@@ -354,8 +353,15 @@ static void net_get_attr(MEX_ARGS) {
       "Usage: caffe_('net_get_attr', hNet)");
   Net<float>* net = handle_to_ptr<Net<float> >(prhs[0]);
   const int net_attr_num = 8;
-  const char* net_attrs[net_attr_num] = { "hLayer_layers", "hBlob_blobs",
-    "input_blob_indices", "output_blob_indices", "layer_names", "blob_names", "bottom_id_vecs", "top_id_vecs" };
+  const char* net_attrs[net_attr_num] = {
+    "hLayer_layers",
+    "hBlob_blobs",
+    "input_blob_indices",
+    "output_blob_indices",
+    "layer_names",
+    "blob_names",
+    "bottom_id_vecs",
+    "top_id_vecs" };
   mxArray* mx_net_attr = mxCreateStructMatrix(1, 1, net_attr_num,
       net_attrs);
   mxSetField(mx_net_attr, 0, "hLayer_layers",
@@ -496,7 +502,8 @@ static void blob_get_data(MEX_ARGS) {
 
 // Usage: caffe_('blob_set_data', hBlob, new_data)
 static void blob_set_data(MEX_ARGS) {
-  mxCHECK(nrhs == 2 && mxIsStruct(prhs[0]) && (mxIsSingle(prhs[1]) || mxIsGPUArray(prhs[1])),
+  mxCHECK(nrhs == 2 && mxIsStruct(prhs[0]) &&
+    (mxIsSingle(prhs[1]) || mxIsGPUArray(prhs[1])),
       "Usage: caffe_('blob_set_data', hBlob, new_data)");
   Blob<float>* blob = handle_to_ptr<Blob<float> >(prhs[0]);
   mx_mat_to_blob(prhs[1], blob, DATA);
@@ -508,10 +515,9 @@ static void blob_copy_data(MEX_ARGS) {
     "Usage: caffe_('blob_copy_data', hBlob_to, hBlob_from)");
   Blob<float>* blob_to = handle_to_ptr<Blob<float> >(prhs[0]);
   Blob<float>* blob_from = handle_to_ptr<Blob<float> >(prhs[1]);
-  //mxCHECK(blob_from->count() == blob_to->count(),
-  //	"number of elements in target blob doesn't match that in source blob");
-  
-  blob_to->CopyFrom(*blob_from, false, true); 
+  // mxCHECK(blob_from->count() == blob_to->count(),
+  // "number of elements in target blob doesn't match that in source blob");
+  blob_to->CopyFrom(*blob_from, false, true);
 }
 
 // Usage: caffe_('blob_get_diff', hBlob)
@@ -576,22 +582,20 @@ static void set_random_seed(MEX_ARGS) {
   Caffe::set_random_seed(random_seed);
 }
 
-static void glog_failure_handler(){
+static void glog_failure_handler() {
   static bool is_glog_failure = false;
-  if (!is_glog_failure)
-  {
+  if (!is_glog_failure) {
     is_glog_failure = true;
     ::google::FlushLogFiles(0);
     mexErrMsgTxt("glog check error, please check log and clear mex");
   }
 }
 
-static void protobuf_log_handler(::google::protobuf::LogLevel level, const char* filename, int line,
-  const std::string& message)
-{
-  const int max_err_length = 512;
-  char err_message[max_err_length];
-  snprintf(err_message, max_err_length, "Protobuf : %s . at %s Line %d",
+static void protobuf_log_handler(::google::protobuf::LogLevel level,
+  const char* filename, int line, const std::string& message) {
+  const int kMaxErrLength = 512;
+  char err_message[kMaxErrLength];
+  snprintf(err_message, kMaxErrLength, "Protobuf : %s . at %s Line %d",
            message.c_str(), filename, line);
   LOG(INFO) << err_message;
   ::google::FlushLogFiles(0);

--- a/matlab/+caffe/set_random_seed.m
+++ b/matlab/+caffe/set_random_seed.m
@@ -1,0 +1,11 @@
+function set_random_seed(random_seed)
+% set_random_seed(random_seed)
+%   set Caffe's random_seed
+
+CHECK(isscalar(random_seed) && random_seed >= 0, ...
+  'random_seed must be non-negative integer');
+random_seed = double(random_seed);
+
+caffe_('set_random_seed', random_seed);
+
+end

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -399,7 +399,7 @@ BOOST_PYTHON_MODULE(_caffe) {
   bp::def("solver_rank", &Caffe::solver_rank);
   bp::def("set_solver_rank", &Caffe::set_solver_rank);
   bp::def("set_multiprocess", &Caffe::set_multiprocess);
-
+  bp::def("set_random_seed", &Caffe::set_random_seed);
   bp::def("layer_type_list", &LayerRegistry<Dtype>::LayerTypeList);
 
   bp::class_<Net<Dtype>, shared_ptr<Net<Dtype> >, boost::noncopyable >("Net",

--- a/src/caffe/layers/batch_norm_layer.cpp
+++ b/src/caffe/layers/batch_norm_layer.cpp
@@ -60,9 +60,7 @@ void BatchNormLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
   mean_.Reshape(sz);
   variance_.Reshape(sz);
   temp_.ReshapeLike(*bottom[0]);
-  if (use_global_stats_) {
-    x_norm_.ReshapeLike(*bottom[0]);
-  }
+  x_norm_.ReshapeLike(*bottom[0]);
   sz[0]=bottom[0]->shape(0);
   batch_sum_multiplier_.Reshape(sz);
 

--- a/src/caffe/layers/batch_norm_layer.cpp
+++ b/src/caffe/layers/batch_norm_layer.cpp
@@ -60,8 +60,10 @@ void BatchNormLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
   mean_.Reshape(sz);
   variance_.Reshape(sz);
   temp_.ReshapeLike(*bottom[0]);
-  x_norm_.ReshapeLike(*bottom[0]);
-  sz[0] = bottom[0]->shape(0);
+  if (use_global_stats_) {
+	  x_norm_.ReshapeLike(*bottom[0]);
+  }
+  sz[0]=bottom[0]->shape(0);
   batch_sum_multiplier_.Reshape(sz);
 
   int spatial_dim = bottom[0]->count()/(channels_*bottom[0]->shape(0));

--- a/src/caffe/layers/batch_norm_layer.cpp
+++ b/src/caffe/layers/batch_norm_layer.cpp
@@ -61,7 +61,7 @@ void BatchNormLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
   variance_.Reshape(sz);
   temp_.ReshapeLike(*bottom[0]);
   if (use_global_stats_) {
-	  x_norm_.ReshapeLike(*bottom[0]);
+    x_norm_.ReshapeLike(*bottom[0]);
   }
   sz[0]=bottom[0]->shape(0);
   batch_sum_multiplier_.Reshape(sz);

--- a/src/caffe/layers/batch_norm_layer.cu
+++ b/src/caffe/layers/batch_norm_layer.cu
@@ -101,9 +101,9 @@ void BatchNormLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
   } else {
     if (use_global_stats_) {
       top_diff = top[0]->gpu_diff();
-    }
-    else {
-      caffe_copy(x_norm_.count(), top[0]->gpu_diff(), x_norm_.mutable_gpu_diff());
+    } else {
+      caffe_copy(x_norm_.count(), top[0]->gpu_diff(),
+      x_norm_.mutable_gpu_diff());
       top_diff = x_norm_.gpu_diff();
     }
   }

--- a/src/caffe/layers/batch_norm_layer.cu
+++ b/src/caffe/layers/batch_norm_layer.cu
@@ -85,8 +85,10 @@ void BatchNormLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
   caffe_gpu_div(temp_.count(), top_data, temp_.gpu_data(), top_data);
   // TODO(cdoersch): The caching is only needed because later in-place layers
   //                 might clobber the data.  Can we skip this if they won't?
-  caffe_copy(x_norm_.count(), top_data,
-      x_norm_.mutable_gpu_data());
+  if (!use_global_stats_) {
+	  caffe_copy(x_norm_.count(), top_data,
+		  x_norm_.mutable_gpu_data());
+  }
 }
 
 template <typename Dtype>
@@ -97,8 +99,13 @@ void BatchNormLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
   if (bottom[0] != top[0]) {
     top_diff = top[0]->gpu_diff();
   } else {
-    caffe_copy(x_norm_.count(), top[0]->gpu_diff(), x_norm_.mutable_gpu_diff());
-    top_diff = x_norm_.gpu_diff();
+	  if (use_global_stats_) {
+		  top_diff = top[0]->gpu_diff();
+	  }
+	  else {
+		  caffe_copy(x_norm_.count(), top[0]->gpu_diff(), x_norm_.mutable_gpu_diff());
+		  top_diff = x_norm_.gpu_diff();
+	  }
   }
   Dtype* bottom_diff = bottom[0]->mutable_gpu_diff();
   if (use_global_stats_) {

--- a/src/caffe/layers/batch_norm_layer.cu
+++ b/src/caffe/layers/batch_norm_layer.cu
@@ -86,8 +86,8 @@ void BatchNormLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
   // TODO(cdoersch): The caching is only needed because later in-place layers
   //                 might clobber the data.  Can we skip this if they won't?
   if (!use_global_stats_) {
-	  caffe_copy(x_norm_.count(), top_data,
-		  x_norm_.mutable_gpu_data());
+    caffe_copy(x_norm_.count(), top_data,
+      x_norm_.mutable_gpu_data());
   }
 }
 
@@ -99,13 +99,13 @@ void BatchNormLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
   if (bottom[0] != top[0]) {
     top_diff = top[0]->gpu_diff();
   } else {
-	  if (use_global_stats_) {
-		  top_diff = top[0]->gpu_diff();
-	  }
-	  else {
-		  caffe_copy(x_norm_.count(), top[0]->gpu_diff(), x_norm_.mutable_gpu_diff());
-		  top_diff = x_norm_.gpu_diff();
-	  }
+    if (use_global_stats_) {
+      top_diff = top[0]->gpu_diff();
+    }
+    else {
+      caffe_copy(x_norm_.count(), top[0]->gpu_diff(), x_norm_.mutable_gpu_diff());
+      top_diff = x_norm_.gpu_diff();
+    }
   }
   Dtype* bottom_diff = bottom[0]->mutable_gpu_diff();
   if (use_global_stats_) {

--- a/src/caffe/layers/box_annotator_ohem_layer.cpp
+++ b/src/caffe/layers/box_annotator_ohem_layer.cpp
@@ -1,0 +1,85 @@
+// ------------------------------------------------------------------
+// R-FCN
+// Copyright (c) 2016 Microsoft
+// Licensed under The MIT License [see r-fcn/LICENSE for details]
+// Written by Yi Li
+// ------------------------------------------------------------------
+
+#include <cfloat>
+
+#include <string>
+#include <utility>
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/layers/box_annotator_ohem_layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+using std::max;
+using std::min;
+using std::floor;
+using std::ceil;
+
+namespace caffe {
+
+  template <typename Dtype>
+  void BoxAnnotatorOHEMLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+    BoxAnnotatorOHEMParameter box_anno_param = this->layer_param_.box_annotator_ohem_param();
+    roi_per_img_ = box_anno_param.roi_per_img();
+    CHECK_GT(roi_per_img_, 0);
+    ignore_label_ = box_anno_param.ignore_label();
+  }
+
+  template <typename Dtype>
+  void BoxAnnotatorOHEMLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+    num_ = bottom[0]->num();
+    CHECK_EQ(5, bottom[0]->channels());
+    height_ = bottom[0]->height();
+    width_ = bottom[0]->width();
+    spatial_dim_ = height_*width_;
+    
+    CHECK_EQ(bottom[1]->num(), num_);
+    CHECK_EQ(bottom[1]->channels(), 1);
+    CHECK_EQ(bottom[1]->height(), height_);
+    CHECK_EQ(bottom[1]->width(), width_);
+
+    CHECK_EQ(bottom[2]->num(), num_);
+    CHECK_EQ(bottom[2]->channels(), 1);
+    CHECK_EQ(bottom[2]->height(), height_);
+    CHECK_EQ(bottom[2]->width(), width_);
+
+    CHECK_EQ(bottom[3]->num(), num_);
+    bbox_channels_ = bottom[3]->channels();
+    CHECK_EQ(bottom[3]->height(), height_);
+    CHECK_EQ(bottom[3]->width(), width_);
+
+    // Labels for scoring
+    top[0]->Reshape(num_, 1, height_, width_);
+    // Loss weights for bbox regression
+    top[1]->Reshape(num_, bbox_channels_, height_, width_);
+  }
+
+  template <typename Dtype>
+  void BoxAnnotatorOHEMLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+    NOT_IMPLEMENTED;
+  }
+
+  template <typename Dtype>
+  void BoxAnnotatorOHEMLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+    NOT_IMPLEMENTED;
+  }
+
+
+#ifdef CPU_ONLY
+  STUB_GPU(BoxAnnotatorOHEMLayer);
+#endif
+
+  INSTANTIATE_CLASS(BoxAnnotatorOHEMLayer);
+  REGISTER_LAYER_CLASS(BoxAnnotatorOHEM);
+
+}  // namespace caffe

--- a/src/caffe/layers/box_annotator_ohem_layer.cpp
+++ b/src/caffe/layers/box_annotator_ohem_layer.cpp
@@ -1,7 +1,5 @@
 // ------------------------------------------------------------------
 // R-FCN
-// Copyright (c) 2016 Microsoft
-// Licensed under The MIT License [see r-fcn/LICENSE for details]
 // Written by Yi Li
 // ------------------------------------------------------------------
 
@@ -9,6 +7,7 @@
 
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "caffe/blob.hpp"
 #include "caffe/common.hpp"
@@ -24,9 +23,11 @@ using std::ceil;
 namespace caffe {
 
   template <typename Dtype>
-  void BoxAnnotatorOHEMLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+  void BoxAnnotatorOHEMLayer<Dtype>::LayerSetUp(
+    const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
-    BoxAnnotatorOHEMParameter box_anno_param = this->layer_param_.box_annotator_ohem_param();
+    BoxAnnotatorOHEMParameter box_anno_param =
+      this->layer_param_.box_annotator_ohem_param();
     roi_per_img_ = box_anno_param.roi_per_img();
     CHECK_GT(roi_per_img_, 0);
     ignore_label_ = box_anno_param.ignore_label();
@@ -40,7 +41,7 @@ namespace caffe {
     height_ = bottom[0]->height();
     width_ = bottom[0]->width();
     spatial_dim_ = height_*width_;
-    
+
     CHECK_EQ(bottom[1]->num(), num_);
     CHECK_EQ(bottom[1]->channels(), 1);
     CHECK_EQ(bottom[1]->height(), height_);
@@ -63,14 +64,15 @@ namespace caffe {
   }
 
   template <typename Dtype>
-  void BoxAnnotatorOHEMLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
-    const vector<Blob<Dtype>*>& top) {
+  void BoxAnnotatorOHEMLayer<Dtype>::Forward_cpu(
+    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
     NOT_IMPLEMENTED;
   }
 
   template <typename Dtype>
-  void BoxAnnotatorOHEMLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
-    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+  void BoxAnnotatorOHEMLayer<Dtype>::Backward_cpu(
+    const vector<Blob<Dtype>*>& top, const vector<bool>& propagate_down,
+    const vector<Blob<Dtype>*>& bottom) {
     NOT_IMPLEMENTED;
   }
 

--- a/src/caffe/layers/box_annotator_ohem_layer.cu
+++ b/src/caffe/layers/box_annotator_ohem_layer.cu
@@ -1,0 +1,79 @@
+// ------------------------------------------------------------------
+// R-FCN
+// Copyright (c) 2016 Microsoft
+// Licensed under The MIT License [see r-fcn/LICENSE for details]
+// Written by Yi Li
+// ------------------------------------------------------------------
+
+#include <algorithm>
+#include <cfloat>
+#include <vector>
+
+#include "caffe/layers/box_annotator_ohem_layer.hpp"
+
+using std::max;
+using std::min;
+
+namespace caffe {  
+  template <typename Dtype>
+  void BoxAnnotatorOHEMLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+    const Dtype* bottom_rois = bottom[0]->cpu_data();
+    const Dtype* bottom_loss = bottom[1]->cpu_data();
+    const Dtype* bottom_labels = bottom[2]->cpu_data();
+    const Dtype* bottom_bbox_loss_weights = bottom[3]->cpu_data();
+    Dtype* top_labels = top[0]->mutable_cpu_data();
+    Dtype* top_bbox_loss_weights = top[1]->mutable_cpu_data();
+    caffe_set(top[0]->count(), Dtype(ignore_label_), top_labels);
+    caffe_set(top[1]->count(), Dtype(0), top_bbox_loss_weights);
+
+    int num_rois_ = bottom[1]->count();
+
+    int num_imgs = -1;
+    for (int n = 0; n < num_rois_; n++){
+      for (int s = 0; s < spatial_dim_; s++){
+        num_imgs = bottom_rois[0]>num_imgs ? bottom_rois[0] : num_imgs;
+        bottom_rois++;
+      }
+      bottom_rois += (5-1)*spatial_dim_;
+    }
+    num_imgs++;
+    CHECK_GT(num_imgs, 0)
+      << "number of images must be greater than 0 at BoxAnnotatorOHEMLayer";
+    bottom_rois = bottom[0]->cpu_data();
+
+    // Find rois with max loss
+    vector<int> sorted_idx(num_rois_);
+    for (int i = 0; i < num_rois_; i++){
+      sorted_idx[i] = i;
+    }
+    std::sort(sorted_idx.begin(), sorted_idx.end(),
+      [bottom_loss](int i1, int i2){return bottom_loss[i1] > bottom_loss[i2]; });
+
+    // Generate output labels for scoring and loss_weights for bbox regression
+    vector<int> number_left(num_imgs, roi_per_img_);
+    for (int i = 0; i < num_rois_; i++){
+      int index = sorted_idx[i];
+      int s = index % (width_*height_);
+      int n = index / (width_*height_);
+      int batch_ind = bottom_rois[n*5*spatial_dim_+s];
+      if (number_left[batch_ind]>0){
+        number_left[batch_ind]--;
+        top_labels[index] = bottom_labels[index];
+        for (int j = 0; j < bbox_channels_; j++){
+          int bbox_index = (n*bbox_channels_+j)*spatial_dim_+s;
+          top_bbox_loss_weights[bbox_index]=bottom_bbox_loss_weights[bbox_index];
+        }
+      }
+    }
+  }
+
+  template <typename Dtype>
+  void BoxAnnotatorOHEMLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+    return;
+  }
+
+  INSTANTIATE_LAYER_GPU_FUNCS(BoxAnnotatorOHEMLayer);
+
+}  // namespace caffe

--- a/src/caffe/layers/box_annotator_ohem_layer.cu
+++ b/src/caffe/layers/box_annotator_ohem_layer.cu
@@ -1,7 +1,5 @@
 // ------------------------------------------------------------------
 // R-FCN
-// Copyright (c) 2016 Microsoft
-// Licensed under The MIT License [see r-fcn/LICENSE for details]
 // Written by Yi Li
 // ------------------------------------------------------------------
 
@@ -14,9 +12,10 @@
 using std::max;
 using std::min;
 
-namespace caffe {  
+namespace caffe {
   template <typename Dtype>
-  void BoxAnnotatorOHEMLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+  void BoxAnnotatorOHEMLayer<Dtype>::Forward_gpu(
+    const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
     const Dtype* bottom_rois = bottom[0]->cpu_data();
     const Dtype* bottom_loss = bottom[1]->cpu_data();
@@ -30,9 +29,9 @@ namespace caffe {
     int num_rois_ = bottom[1]->count();
 
     int num_imgs = -1;
-    for (int n = 0; n < num_rois_; n++){
-      for (int s = 0; s < spatial_dim_; s++){
-        num_imgs = bottom_rois[0]>num_imgs ? bottom_rois[0] : num_imgs;
+    for (int n = 0; n < num_rois_; n++) {
+      for (int s = 0; s < spatial_dim_; s++) {
+        num_imgs = bottom_rois[0] > num_imgs ? bottom_rois[0] : num_imgs;
         bottom_rois++;
       }
       bottom_rois += (5-1)*spatial_dim_;
@@ -44,33 +43,37 @@ namespace caffe {
 
     // Find rois with max loss
     vector<int> sorted_idx(num_rois_);
-    for (int i = 0; i < num_rois_; i++){
+    for (int i = 0; i < num_rois_; i++) {
       sorted_idx[i] = i;
     }
     std::sort(sorted_idx.begin(), sorted_idx.end(),
-      [bottom_loss](int i1, int i2){return bottom_loss[i1] > bottom_loss[i2]; });
+      [bottom_loss](int i1, int i2) {
+        return bottom_loss[i1] > bottom_loss[i2];
+    });
 
     // Generate output labels for scoring and loss_weights for bbox regression
     vector<int> number_left(num_imgs, roi_per_img_);
-    for (int i = 0; i < num_rois_; i++){
+    for (int i = 0; i < num_rois_; i++) {
       int index = sorted_idx[i];
       int s = index % (width_*height_);
       int n = index / (width_*height_);
       int batch_ind = bottom_rois[n*5*spatial_dim_+s];
-      if (number_left[batch_ind]>0){
+      if (number_left[batch_ind] > 0) {
         number_left[batch_ind]--;
         top_labels[index] = bottom_labels[index];
-        for (int j = 0; j < bbox_channels_; j++){
+        for (int j = 0; j < bbox_channels_; j++) {
           int bbox_index = (n*bbox_channels_+j)*spatial_dim_+s;
-          top_bbox_loss_weights[bbox_index]=bottom_bbox_loss_weights[bbox_index];
+          top_bbox_loss_weights[bbox_index] =
+            bottom_bbox_loss_weights[bbox_index];
         }
       }
     }
   }
 
   template <typename Dtype>
-  void BoxAnnotatorOHEMLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
-    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+  void BoxAnnotatorOHEMLayer<Dtype>::Backward_gpu(
+    const vector<Blob<Dtype>*>& top, const vector<bool>& propagate_down,
+    const vector<Blob<Dtype>*>& bottom) {
     return;
   }
 

--- a/src/caffe/layers/dropout_layer.cpp
+++ b/src/caffe/layers/dropout_layer.cpp
@@ -16,6 +16,7 @@ void DropoutLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
   DCHECK(threshold_ < 1.);
   scale_ = 1. / (1. - threshold_);
   uint_thres_ = static_cast<unsigned int>(UINT_MAX * threshold_);
+  scale_train_ = this->layer_param_.dropout_param().scale_train();
 }
 
 template <typename Dtype>
@@ -37,11 +38,20 @@ void DropoutLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
   if (this->phase_ == TRAIN) {
     // Create random numbers
     caffe_rng_bernoulli(count, 1. - threshold_, mask);
-    for (int i = 0; i < count; ++i) {
-      top_data[i] = bottom_data[i] * mask[i] * scale_;
+    if (scale_train_) {
+      for (int i = 0; i < count; ++i) {
+        top_data[i] = bottom_data[i] * mask[i] * scale_;
+      }
+    } else {
+      for (int i = 0; i < count; ++i) {
+        top_data[i] = bottom_data[i] * mask[i];
+      }
     }
   } else {
     caffe_copy(bottom[0]->count(), bottom_data, top_data);
+    if (!scale_train_) {
+      caffe_scal<Dtype>(count, 1. / scale_, top_data);
+    }
   }
 }
 
@@ -55,11 +65,20 @@ void DropoutLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
     if (this->phase_ == TRAIN) {
       const unsigned int* mask = rand_vec_.cpu_data();
       const int count = bottom[0]->count();
-      for (int i = 0; i < count; ++i) {
-        bottom_diff[i] = top_diff[i] * mask[i] * scale_;
+      if (scale_train_) {
+        for (int i = 0; i < count; ++i) {
+          bottom_diff[i] = top_diff[i] * mask[i] * scale_;
+        }
+      } else {
+        for (int i = 0; i < count; ++i) {
+          bottom_diff[i] = top_diff[i] * mask[i];
+        }
       }
     } else {
       caffe_copy(top[0]->count(), top_diff, bottom_diff);
+      if (!scale_train_) {
+        caffe_scal<Dtype>(top[0]->count(), 1. / scale_, bottom_diff);
+      }
     }
   }
 }

--- a/src/caffe/layers/psroi_pooling_layer.cpp
+++ b/src/caffe/layers/psroi_pooling_layer.cpp
@@ -1,7 +1,5 @@
 // ------------------------------------------------------------------
 // R-FCN
-// Copyright (c) 2016 Microsoft
-// Licensed under The MIT License [see r-fcn/LICENSE for details]
 // Written by Yi Li
 // ------------------------------------------------------------------
 
@@ -21,8 +19,9 @@ using std::ceil;
 namespace caffe {
   template <typename Dtype>
   void PSROIPoolingLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
-    const vector<Blob<Dtype>*>& top){
-    PSROIPoolingParameter psroi_pooling_param = this->layer_param_.psroi_pooling_param();
+    const vector<Blob<Dtype>*>& top) {
+    PSROIPoolingParameter psroi_pooling_param =
+      this->layer_param_.psroi_pooling_param();
     spatial_scale_ = psroi_pooling_param.spatial_scale();
     LOG(INFO) << "Spatial scale: " << spatial_scale_;
 
@@ -45,19 +44,21 @@ namespace caffe {
       << "input channel number does not match layer parameters";
     height_ = bottom[0]->height();
     width_ = bottom[0]->width();
-    top[0]->Reshape(bottom[1]->num(), output_dim_, pooled_height_, pooled_width_);
-    mapping_channel_.Reshape(bottom[1]->num(), output_dim_, pooled_height_, pooled_width_);
+    top[0]->Reshape(
+      bottom[1]->num(), output_dim_, pooled_height_, pooled_width_);
+    mapping_channel_.Reshape(
+      bottom[1]->num(), output_dim_, pooled_height_, pooled_width_);
   }
 
   template <typename Dtype>
   void PSROIPoolingLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
-    const vector<Blob<Dtype>*>& top){
+    const vector<Blob<Dtype>*>& top) {
     NOT_IMPLEMENTED;
   }
 
   template <typename Dtype>
   void PSROIPoolingLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
-    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom){
+    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
     NOT_IMPLEMENTED;
   }
 #ifdef CPU_ONLY
@@ -67,4 +68,4 @@ namespace caffe {
   INSTANTIATE_CLASS(PSROIPoolingLayer);
   REGISTER_LAYER_CLASS(PSROIPooling);
 
-}
+}  // namespace caffe

--- a/src/caffe/layers/psroi_pooling_layer.cpp
+++ b/src/caffe/layers/psroi_pooling_layer.cpp
@@ -1,0 +1,70 @@
+// ------------------------------------------------------------------
+// R-FCN
+// Copyright (c) 2016 Microsoft
+// Licensed under The MIT License [see r-fcn/LICENSE for details]
+// Written by Yi Li
+// ------------------------------------------------------------------
+
+#include <cfloat>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "caffe/layers/psroi_pooling_layer.hpp"
+
+using std::max;
+using std::min;
+using std::floor;
+using std::ceil;
+
+namespace caffe {
+  template <typename Dtype>
+  void PSROIPoolingLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top){
+    PSROIPoolingParameter psroi_pooling_param = this->layer_param_.psroi_pooling_param();
+    spatial_scale_ = psroi_pooling_param.spatial_scale();
+    LOG(INFO) << "Spatial scale: " << spatial_scale_;
+
+    CHECK_GT(psroi_pooling_param.output_dim(), 0)
+      << "output_dim must be > 0";
+    CHECK_GT(psroi_pooling_param.group_size(), 0)
+      << "group_size must be > 0";
+
+    output_dim_ = psroi_pooling_param.output_dim();
+    group_size_ = psroi_pooling_param.group_size();
+    pooled_height_ = group_size_;
+    pooled_width_ = group_size_;
+  }
+
+  template <typename Dtype>
+  void PSROIPoolingLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+    channels_ = bottom[0]->channels();
+    CHECK_EQ(channels_, output_dim_*group_size_*group_size_)
+      << "input channel number does not match layer parameters";
+    height_ = bottom[0]->height();
+    width_ = bottom[0]->width();
+    top[0]->Reshape(bottom[1]->num(), output_dim_, pooled_height_, pooled_width_);
+    mapping_channel_.Reshape(bottom[1]->num(), output_dim_, pooled_height_, pooled_width_);
+  }
+
+  template <typename Dtype>
+  void PSROIPoolingLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top){
+    NOT_IMPLEMENTED;
+  }
+
+  template <typename Dtype>
+  void PSROIPoolingLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom){
+    NOT_IMPLEMENTED;
+  }
+#ifdef CPU_ONLY
+  STUB_GPU(PSROIPoolingLayer);
+#endif
+
+  INSTANTIATE_CLASS(PSROIPoolingLayer);
+  REGISTER_LAYER_CLASS(PSROIPooling);
+
+}

--- a/src/caffe/layers/psroi_pooling_layer.cu
+++ b/src/caffe/layers/psroi_pooling_layer.cu
@@ -121,7 +121,7 @@ namespace caffe {
       int ph = (index / pooled_width) % pooled_height;
       int n = index / pooled_width / pooled_height / output_dim;
 
-			// [start, end) interval for spatial sampling
+      // [start, end) interval for spatial sampling
       bottom_rois += n * 5;
       int roi_batch_ind = bottom_rois[0];
       Dtype roi_start_w = static_cast<Dtype>(round(bottom_rois[1])) * spatial_scale;

--- a/src/caffe/layers/psroi_pooling_layer.cu
+++ b/src/caffe/layers/psroi_pooling_layer.cu
@@ -1,0 +1,194 @@
+// ------------------------------------------------------------------
+// R-FCN
+// Copyright (c) 2016 Microsoft
+// Licensed under The MIT License [see r-fcn/LICENSE for details]
+// Written by Yi Li
+// ------------------------------------------------------------------
+
+#include <cfloat>
+
+#include "caffe/layers/psroi_pooling_layer.hpp"
+#include "caffe/util/gpu_util.cuh"
+
+using std::max;
+using std::min;
+
+namespace caffe {
+
+  template <typename Dtype>
+  __global__ void PSROIPoolingForward(
+    const int nthreads,
+    const Dtype* bottom_data,
+    const Dtype spatial_scale,
+    const int channels,
+    const int height, const int width,
+    const int pooled_height, const int pooled_width,
+    const Dtype* bottom_rois,
+    const int output_dim,
+    const int group_size,
+    Dtype* top_data,
+    int* mapping_channel) {
+    CUDA_KERNEL_LOOP(index, nthreads) {
+      // The output is in order (n, ctop, ph, pw)
+      int pw = index % pooled_width;
+      int ph = (index / pooled_width) % pooled_height;
+      int ctop = (index / pooled_width / pooled_height) % output_dim;
+      int n = index / pooled_width / pooled_height / output_dim;
+
+      // [start, end) interval for spatial sampling
+      bottom_rois += n * 5;
+      int roi_batch_ind = bottom_rois[0];
+      Dtype roi_start_w = static_cast<Dtype>(round(bottom_rois[1])) * spatial_scale;
+      Dtype roi_start_h = static_cast<Dtype>(round(bottom_rois[2])) * spatial_scale;
+      Dtype roi_end_w = static_cast<Dtype>(round(bottom_rois[3]) + 1.) * spatial_scale;
+      Dtype roi_end_h = static_cast<Dtype>(round(bottom_rois[4]) + 1.) * spatial_scale;
+
+      // Force too small ROIs to be 1x1
+      Dtype roi_width = max(roi_end_w - roi_start_w, 0.1); //avoid 0
+      Dtype roi_height = max(roi_end_h - roi_start_h, 0.1);
+
+      // Compute w and h at bottom 
+      Dtype bin_size_h = roi_height / static_cast<Dtype>(pooled_height);
+      Dtype bin_size_w = roi_width / static_cast<Dtype>(pooled_width);
+
+      int hstart = floor(static_cast<Dtype>(ph) * bin_size_h
+                          + roi_start_h);
+      int wstart = floor(static_cast<Dtype>(pw)* bin_size_w
+                          + roi_start_w);
+      int hend = ceil(static_cast<Dtype>(ph + 1) * bin_size_h
+                        + roi_start_h);
+      int wend = ceil(static_cast<Dtype>(pw + 1) * bin_size_w
+                        + roi_start_w);
+      // Add roi offsets and clip to input boundaries
+      hstart = min(max(hstart, 0), height);
+      hend = min(max(hend, 0), height);
+      wstart = min(max(wstart, 0),width);
+      wend = min(max(wend, 0), width);
+      bool is_empty = (hend <= hstart) || (wend <= wstart);
+
+      int gw = pw;
+      int gh = ph;
+      int c = (ctop*group_size + gh)*group_size + gw;
+
+      bottom_data += (roi_batch_ind * channels + c) * height * width;
+      Dtype out_sum = 0;
+      for (int h = hstart; h < hend; ++h){
+        for (int w = wstart; w < wend; ++w){
+          int bottom_index = h*width + w;
+          out_sum += bottom_data[bottom_index];
+        }
+      }
+
+      Dtype bin_area = (hend - hstart)*(wend - wstart);
+      top_data[index] = is_empty? 0. : out_sum/bin_area;
+      mapping_channel[index] = c;
+    }
+  }
+
+  template <typename Dtype>
+  void PSROIPoolingLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+    const Dtype* bottom_data = bottom[0]->gpu_data();
+    const Dtype* bottom_rois = bottom[1]->gpu_data();
+    Dtype* top_data = top[0]->mutable_gpu_data();
+    int* mapping_channel_ptr = mapping_channel_.mutable_gpu_data();
+    int count = top[0]->count();
+    caffe_gpu_set(count, Dtype(0), top_data);
+    caffe_gpu_set(count, -1, mapping_channel_ptr);
+    // NOLINT_NEXT_LINE(whitespace/operators)
+    PSROIPoolingForward<Dtype> << <CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS >> >(
+      count, bottom_data, spatial_scale_, channels_, height_, width_, pooled_height_,
+      pooled_width_, bottom_rois, output_dim_, group_size_, top_data, mapping_channel_ptr);
+    CUDA_POST_KERNEL_CHECK;
+  }
+
+  template <typename Dtype>
+  __global__ void PSROIPoolingBackwardAtomic(
+    const int nthreads,
+    const Dtype* top_diff,
+    const int* mapping_channel,
+    const int num_rois,
+    const Dtype spatial_scale,
+    const int channels,
+    const int height, const int width,
+    const int pooled_height, const int pooled_width,
+    const int output_dim, 
+    Dtype* bottom_diff,
+    const Dtype* bottom_rois) {
+    CUDA_KERNEL_LOOP(index, nthreads) {
+      // The output is in order (n, ctop, ph, pw)
+      int pw = index % pooled_width;
+      int ph = (index / pooled_width) % pooled_height;
+      int n = index / pooled_width / pooled_height / output_dim;
+
+			// [start, end) interval for spatial sampling
+      bottom_rois += n * 5;
+      int roi_batch_ind = bottom_rois[0];
+      Dtype roi_start_w = static_cast<Dtype>(round(bottom_rois[1])) * spatial_scale;
+      Dtype roi_start_h = static_cast<Dtype>(round(bottom_rois[2])) * spatial_scale;
+      Dtype roi_end_w = static_cast<Dtype>(round(bottom_rois[3]) + 1.) * spatial_scale;
+      Dtype roi_end_h = static_cast<Dtype>(round(bottom_rois[4]) + 1.) * spatial_scale;
+
+      // Force too small ROIs to be 1x1
+      Dtype roi_width = max(roi_end_w - roi_start_w, 0.1); //avoid 0
+      Dtype roi_height = max(roi_end_h - roi_start_h, 0.1);
+
+      // Compute w and h at bottom 
+      Dtype bin_size_h = roi_height / static_cast<Dtype>(pooled_height);
+      Dtype bin_size_w = roi_width / static_cast<Dtype>(pooled_width);
+
+      int hstart = floor(static_cast<Dtype>(ph)* bin_size_h
+        + roi_start_h);
+      int wstart = floor(static_cast<Dtype>(pw)* bin_size_w
+        + roi_start_w);
+      int hend = ceil(static_cast<Dtype>(ph + 1) * bin_size_h
+        + roi_start_h);
+      int wend = ceil(static_cast<Dtype>(pw + 1) * bin_size_w
+        + roi_start_w);
+      // Add roi offsets and clip to input boundaries
+      hstart = min(max(hstart, 0), height);
+      hend = min(max(hend, 0), height);
+      wstart = min(max(wstart, 0), width);
+      wend = min(max(wend, 0), width);
+      bool is_empty = (hend <= hstart) || (wend <= wstart);
+
+      // Compute c at bottom
+      int c = mapping_channel[index];
+      Dtype* offset_bottom_diff = bottom_diff + (roi_batch_ind * channels + c) * height * width;
+      Dtype bin_area = (hend - hstart)*(wend - wstart);
+      Dtype diff_val = is_empty ? 0. : top_diff[index] / bin_area;
+      for (int h = hstart; h < hend; ++h){
+        for (int w = wstart; w < wend; ++w){
+          int bottom_index = h*width + w;
+          caffe_gpu_atomic_add(diff_val, offset_bottom_diff + bottom_index);
+        }
+      }
+    }
+  }
+
+  template <typename Dtype>
+  void PSROIPoolingLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+    if (!propagate_down[0]) {
+      return;
+    }
+
+    const Dtype* bottom_rois = bottom[1]->gpu_data();
+    const Dtype* top_diff = top[0]->gpu_diff();
+    Dtype* bottom_diff = bottom[0]->mutable_gpu_diff();
+    const int bottom_count = bottom[0]->count();
+    const int* mapping_channel_ptr = mapping_channel_.gpu_data();
+    caffe_gpu_set(bottom[1]->count(), Dtype(0), bottom[1]->mutable_gpu_diff());
+    caffe_gpu_set(bottom_count, Dtype(0), bottom_diff);
+    const int count = top[0]->count();
+    // NOLINT_NEXT_LINE(whitespace/operators)
+    PSROIPoolingBackwardAtomic<Dtype> << <CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS >> >(
+      count, top_diff, mapping_channel_ptr, top[0]->num(), spatial_scale_,
+      channels_, height_, width_, pooled_height_, pooled_width_, output_dim_,
+      bottom_diff, bottom_rois);
+    CUDA_POST_KERNEL_CHECK;
+  }
+
+  INSTANTIATE_LAYER_GPU_FUNCS(PSROIPoolingLayer);
+
+}  // namespace caffe

--- a/src/caffe/layers/psroi_pooling_layer.cu
+++ b/src/caffe/layers/psroi_pooling_layer.cu
@@ -1,11 +1,11 @@
-// ------------------------------------------------------------------
+// --------------------------------------------------------
 // R-FCN
-// Copyright (c) 2016 Microsoft
-// Licensed under The MIT License [see r-fcn/LICENSE for details]
-// Written by Yi Li
-// ------------------------------------------------------------------
+// Written by Yi Li, 2016.
+// --------------------------------------------------------
 
+#include <algorithm>
 #include <cfloat>
+#include <vector>
 
 #include "caffe/layers/psroi_pooling_layer.hpp"
 #include "caffe/util/gpu_util.cuh"
@@ -38,16 +38,20 @@ namespace caffe {
       // [start, end) interval for spatial sampling
       bottom_rois += n * 5;
       int roi_batch_ind = bottom_rois[0];
-      Dtype roi_start_w = static_cast<Dtype>(round(bottom_rois[1])) * spatial_scale;
-      Dtype roi_start_h = static_cast<Dtype>(round(bottom_rois[2])) * spatial_scale;
-      Dtype roi_end_w = static_cast<Dtype>(round(bottom_rois[3]) + 1.) * spatial_scale;
-      Dtype roi_end_h = static_cast<Dtype>(round(bottom_rois[4]) + 1.) * spatial_scale;
+      Dtype roi_start_w =
+        static_cast<Dtype>(round(bottom_rois[1])) * spatial_scale;
+      Dtype roi_start_h =
+        static_cast<Dtype>(round(bottom_rois[2])) * spatial_scale;
+      Dtype roi_end_w =
+        static_cast<Dtype>(round(bottom_rois[3]) + 1.) * spatial_scale;
+      Dtype roi_end_h =
+        static_cast<Dtype>(round(bottom_rois[4]) + 1.) * spatial_scale;
 
       // Force too small ROIs to be 1x1
-      Dtype roi_width = max(roi_end_w - roi_start_w, 0.1); //avoid 0
+      Dtype roi_width = max(roi_end_w - roi_start_w, 0.1);  // avoid 0
       Dtype roi_height = max(roi_end_h - roi_start_h, 0.1);
 
-      // Compute w and h at bottom 
+      // Compute w and h at bottom
       Dtype bin_size_h = roi_height / static_cast<Dtype>(pooled_height);
       Dtype bin_size_w = roi_width / static_cast<Dtype>(pooled_width);
 
@@ -62,7 +66,7 @@ namespace caffe {
       // Add roi offsets and clip to input boundaries
       hstart = min(max(hstart, 0), height);
       hend = min(max(hend, 0), height);
-      wstart = min(max(wstart, 0),width);
+      wstart = min(max(wstart, 0), width);
       wend = min(max(wend, 0), width);
       bool is_empty = (hend <= hstart) || (wend <= wstart);
 
@@ -72,8 +76,8 @@ namespace caffe {
 
       bottom_data += (roi_batch_ind * channels + c) * height * width;
       Dtype out_sum = 0;
-      for (int h = hstart; h < hend; ++h){
-        for (int w = wstart; w < wend; ++w){
+      for (int h = hstart; h < hend; ++h) {
+        for (int w = wstart; w < wend; ++w) {
           int bottom_index = h*width + w;
           out_sum += bottom_data[bottom_index];
         }
@@ -96,9 +100,11 @@ namespace caffe {
     caffe_gpu_set(count, Dtype(0), top_data);
     caffe_gpu_set(count, -1, mapping_channel_ptr);
     // NOLINT_NEXT_LINE(whitespace/operators)
-    PSROIPoolingForward<Dtype> << <CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS >> >(
-      count, bottom_data, spatial_scale_, channels_, height_, width_, pooled_height_,
-      pooled_width_, bottom_rois, output_dim_, group_size_, top_data, mapping_channel_ptr);
+    PSROIPoolingForward<Dtype> << <CAFFE_GET_BLOCKS(count),
+      CAFFE_CUDA_NUM_THREADS >> >(count, bottom_data, spatial_scale_,
+      channels_, height_, width_, pooled_height_,
+      pooled_width_, bottom_rois, output_dim_, group_size_,
+      top_data, mapping_channel_ptr);
     CUDA_POST_KERNEL_CHECK;
   }
 
@@ -112,7 +118,7 @@ namespace caffe {
     const int channels,
     const int height, const int width,
     const int pooled_height, const int pooled_width,
-    const int output_dim, 
+    const int output_dim,
     Dtype* bottom_diff,
     const Dtype* bottom_rois) {
     CUDA_KERNEL_LOOP(index, nthreads) {
@@ -124,16 +130,20 @@ namespace caffe {
       // [start, end) interval for spatial sampling
       bottom_rois += n * 5;
       int roi_batch_ind = bottom_rois[0];
-      Dtype roi_start_w = static_cast<Dtype>(round(bottom_rois[1])) * spatial_scale;
-      Dtype roi_start_h = static_cast<Dtype>(round(bottom_rois[2])) * spatial_scale;
-      Dtype roi_end_w = static_cast<Dtype>(round(bottom_rois[3]) + 1.) * spatial_scale;
-      Dtype roi_end_h = static_cast<Dtype>(round(bottom_rois[4]) + 1.) * spatial_scale;
+      Dtype roi_start_w =
+        static_cast<Dtype>(round(bottom_rois[1])) * spatial_scale;
+      Dtype roi_start_h =
+        static_cast<Dtype>(round(bottom_rois[2])) * spatial_scale;
+      Dtype roi_end_w =
+        static_cast<Dtype>(round(bottom_rois[3]) + 1.) * spatial_scale;
+      Dtype roi_end_h =
+        static_cast<Dtype>(round(bottom_rois[4]) + 1.) * spatial_scale;
 
       // Force too small ROIs to be 1x1
-      Dtype roi_width = max(roi_end_w - roi_start_w, 0.1); //avoid 0
+      Dtype roi_width = max(roi_end_w - roi_start_w, 0.1);  // avoid 0
       Dtype roi_height = max(roi_end_h - roi_start_h, 0.1);
 
-      // Compute w and h at bottom 
+      // Compute w and h at bottom
       Dtype bin_size_h = roi_height / static_cast<Dtype>(pooled_height);
       Dtype bin_size_w = roi_width / static_cast<Dtype>(pooled_width);
 
@@ -154,11 +164,12 @@ namespace caffe {
 
       // Compute c at bottom
       int c = mapping_channel[index];
-      Dtype* offset_bottom_diff = bottom_diff + (roi_batch_ind * channels + c) * height * width;
+      Dtype* offset_bottom_diff = bottom_diff +
+        (roi_batch_ind * channels + c) * height * width;
       Dtype bin_area = (hend - hstart)*(wend - wstart);
       Dtype diff_val = is_empty ? 0. : top_diff[index] / bin_area;
-      for (int h = hstart; h < hend; ++h){
-        for (int w = wstart; w < wend; ++w){
+      for (int h = hstart; h < hend; ++h) {
+        for (int w = wstart; w < wend; ++w) {
           int bottom_index = h*width + w;
           caffe_gpu_atomic_add(diff_val, offset_bottom_diff + bottom_index);
         }
@@ -182,10 +193,11 @@ namespace caffe {
     caffe_gpu_set(bottom_count, Dtype(0), bottom_diff);
     const int count = top[0]->count();
     // NOLINT_NEXT_LINE(whitespace/operators)
-    PSROIPoolingBackwardAtomic<Dtype> << <CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS >> >(
-      count, top_diff, mapping_channel_ptr, top[0]->num(), spatial_scale_,
-      channels_, height_, width_, pooled_height_, pooled_width_, output_dim_,
-      bottom_diff, bottom_rois);
+    PSROIPoolingBackwardAtomic<Dtype> << <CAFFE_GET_BLOCKS(count),
+      CAFFE_CUDA_NUM_THREADS >> >(count, top_diff, mapping_channel_ptr,
+      top[0]->num(), spatial_scale_, channels_, height_, width_,
+      pooled_height_, pooled_width_, output_dim_, bottom_diff,
+      bottom_rois);
     CUDA_POST_KERNEL_CHECK;
   }
 

--- a/src/caffe/layers/roi_pooling_layer.cpp
+++ b/src/caffe/layers/roi_pooling_layer.cpp
@@ -1,0 +1,136 @@
+#include <algorithm>
+#include <cfloat>
+#include <vector>
+
+#include "caffe/layers/roi_pooling_layer.hpp"
+
+using std::max;
+using std::min;
+using std::floor;
+using std::ceil;
+
+namespace caffe {
+
+template <typename Dtype>
+void ROIPoolingLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  ROIPoolingParameter roi_pool_param = this->layer_param_.roi_pooling_param();
+  CHECK_GT(roi_pool_param.pooled_h(), 0)
+      << "pooled_h must be > 0";
+  CHECK_GT(roi_pool_param.pooled_w(), 0)
+      << "pooled_w must be > 0";
+  pooled_height_ = roi_pool_param.pooled_h();
+  pooled_width_ = roi_pool_param.pooled_w();
+  spatial_scale_ = roi_pool_param.spatial_scale();
+  LOG(INFO) << "Spatial scale: " << spatial_scale_;
+}
+
+template <typename Dtype>
+void ROIPoolingLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  channels_ = bottom[0]->channels();
+  height_ = bottom[0]->height();
+  width_ = bottom[0]->width();
+  top[0]->Reshape(bottom[1]->num(), channels_, pooled_height_,
+      pooled_width_);
+  max_idx_.Reshape(bottom[1]->num(), channels_, pooled_height_,
+      pooled_width_);
+}
+
+template <typename Dtype>
+void ROIPoolingLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  const Dtype* bottom_data = bottom[0]->cpu_data();
+  const Dtype* bottom_rois = bottom[1]->cpu_data();
+  // Number of ROIs
+  int num_rois = bottom[1]->num();
+  int batch_size = bottom[0]->num();
+  int top_count = top[0]->count();
+  Dtype* top_data = top[0]->mutable_cpu_data();
+  caffe_set(top_count, Dtype(-FLT_MAX), top_data);
+  int* argmax_data = max_idx_.mutable_cpu_data();
+  caffe_set(top_count, -1, argmax_data);
+
+  // For each ROI R = [batch_index x1 y1 x2 y2]: max pool over R
+  for (int n = 0; n < num_rois; ++n) {
+    int roi_batch_ind = bottom_rois[0];
+    int roi_start_w = round(bottom_rois[1] * spatial_scale_);
+    int roi_start_h = round(bottom_rois[2] * spatial_scale_);
+    int roi_end_w = round(bottom_rois[3] * spatial_scale_);
+    int roi_end_h = round(bottom_rois[4] * spatial_scale_);
+    CHECK_GE(roi_batch_ind, 0);
+    CHECK_LT(roi_batch_ind, batch_size);
+
+    int roi_height = max(roi_end_h - roi_start_h + 1, 1);
+    int roi_width = max(roi_end_w - roi_start_w + 1, 1);
+    const Dtype bin_size_h = static_cast<Dtype>(roi_height)
+                             / static_cast<Dtype>(pooled_height_);
+    const Dtype bin_size_w = static_cast<Dtype>(roi_width)
+                             / static_cast<Dtype>(pooled_width_);
+
+    const Dtype* batch_data = bottom_data + bottom[0]->offset(roi_batch_ind);
+
+    for (int c = 0; c < channels_; ++c) {
+      for (int ph = 0; ph < pooled_height_; ++ph) {
+        for (int pw = 0; pw < pooled_width_; ++pw) {
+          // Compute pooling region for this output unit:
+          //  start (included) = floor(ph * roi_height / pooled_height_)
+          //  end (excluded) = ceil((ph + 1) * roi_height / pooled_height_)
+          int hstart = static_cast<int>(floor(static_cast<Dtype>(ph)
+                                              * bin_size_h));
+          int wstart = static_cast<int>(floor(static_cast<Dtype>(pw)
+                                              * bin_size_w));
+          int hend = static_cast<int>(ceil(static_cast<Dtype>(ph + 1)
+                                           * bin_size_h));
+          int wend = static_cast<int>(ceil(static_cast<Dtype>(pw + 1)
+                                           * bin_size_w));
+
+          hstart = min(max(hstart + roi_start_h, 0), height_);
+          hend = min(max(hend + roi_start_h, 0), height_);
+          wstart = min(max(wstart + roi_start_w, 0), width_);
+          wend = min(max(wend + roi_start_w, 0), width_);
+
+          bool is_empty = (hend <= hstart) || (wend <= wstart);
+
+          const int pool_index = ph * pooled_width_ + pw;
+          if (is_empty) {
+            top_data[pool_index] = 0;
+            argmax_data[pool_index] = -1;
+          }
+
+          for (int h = hstart; h < hend; ++h) {
+            for (int w = wstart; w < wend; ++w) {
+              const int index = h * width_ + w;
+              if (batch_data[index] > top_data[pool_index]) {
+                top_data[pool_index] = batch_data[index];
+                argmax_data[pool_index] = index;
+              }
+            }
+          }
+        }
+      }
+      // Increment all data pointers by one channel
+      batch_data += bottom[0]->offset(0, 1);
+      top_data += top[0]->offset(0, 1);
+      argmax_data += max_idx_.offset(0, 1);
+    }
+    // Increment ROI data pointer
+    bottom_rois += bottom[1]->offset(1);
+  }
+}
+
+template <typename Dtype>
+void ROIPoolingLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+  NOT_IMPLEMENTED;
+}
+
+
+#ifdef CPU_ONLY
+STUB_GPU(ROIPoolingLayer);
+#endif
+
+INSTANTIATE_CLASS(ROIPoolingLayer);
+REGISTER_LAYER_CLASS(ROIPooling);
+
+}  // namespace caffe

--- a/src/caffe/layers/roi_pooling_layer.cpp
+++ b/src/caffe/layers/roi_pooling_layer.cpp
@@ -122,7 +122,39 @@ void ROIPoolingLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
 template <typename Dtype>
 void ROIPoolingLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
-  NOT_IMPLEMENTED;
+  if (propagate_down[1]) {
+    LOG(FATAL) << this->type()
+               << " Layer cannot backpropagate to roi inputs.";
+  }
+  if (!propagate_down[0]) {
+    return;
+  }
+  const Dtype* bottom_rois = bottom[1]->cpu_data();
+  const Dtype* top_diff = top[0]->cpu_diff();
+  Dtype* bottom_diff = bottom[0]->mutable_cpu_diff();
+  caffe_set(bottom[0]->count(), Dtype(0.), bottom_diff);
+  const int* argmax_data = max_idx_.cpu_data();
+  const int num_rois = top[0]->num();
+
+  // Accumulate gradient over all ROIs
+  for (int roi_n = 0; roi_n < num_rois; ++roi_n) {
+    int roi_batch_ind = bottom_rois[roi_n * 5];
+    // Accumulate gradients over each bin in this ROI
+    for (int c = 0; c < channels_; ++c) {
+      for (int ph = 0; ph < pooled_height_; ++ph) {
+        for (int pw = 0; pw < pooled_width_; ++pw) {
+          int offset_top = ((roi_n * channels_ + c) * pooled_height_ + ph)
+              * pooled_width_ + pw;
+          int argmax_index = argmax_data[offset_top];
+          if (argmax_index >= 0) {
+            int offset_bottom = (roi_batch_ind * channels_ + c) * height_
+                * width_ + argmax_index;
+            bottom_diff[offset_bottom] += top_diff[offset_top];
+          }
+        }
+      }
+    }
+  }
 }
 
 

--- a/src/caffe/layers/roi_pooling_layer.cu
+++ b/src/caffe/layers/roi_pooling_layer.cu
@@ -1,0 +1,184 @@
+#include <algorithm>
+#include <cfloat>
+#include <vector>
+
+#include "caffe/layers/roi_pooling_layer.hpp"
+
+
+using std::max;
+using std::min;
+
+namespace caffe {
+
+template <typename Dtype>
+__global__ void ROIPoolForward(const int nthreads, const Dtype* bottom_data,
+    const Dtype spatial_scale, const int channels, const int height,
+    const int width, const int pooled_height, const int pooled_width,
+    const Dtype* bottom_rois, Dtype* top_data, int* argmax_data) {
+  CUDA_KERNEL_LOOP(index, nthreads) {
+    // (n, c, ph, pw) is an element in the pooled output
+    int pw = index % pooled_width;
+    int ph = (index / pooled_width) % pooled_height;
+    int c = (index / pooled_width / pooled_height) % channels;
+    int n = index / pooled_width / pooled_height / channels;
+
+    bottom_rois += n * 5;
+    int roi_batch_ind = bottom_rois[0];
+    int roi_start_w = round(bottom_rois[1] * spatial_scale);
+    int roi_start_h = round(bottom_rois[2] * spatial_scale);
+    int roi_end_w = round(bottom_rois[3] * spatial_scale);
+    int roi_end_h = round(bottom_rois[4] * spatial_scale);
+
+    // Force malformed ROIs to be 1x1
+    int roi_width = max(roi_end_w - roi_start_w + 1, 1);
+    int roi_height = max(roi_end_h - roi_start_h + 1, 1);
+    Dtype bin_size_h = static_cast<Dtype>(roi_height)
+                       / static_cast<Dtype>(pooled_height);
+    Dtype bin_size_w = static_cast<Dtype>(roi_width)
+                       / static_cast<Dtype>(pooled_width);
+
+    int hstart = static_cast<int>(floor(static_cast<Dtype>(ph)
+                                        * bin_size_h));
+    int wstart = static_cast<int>(floor(static_cast<Dtype>(pw)
+                                        * bin_size_w));
+    int hend = static_cast<int>(ceil(static_cast<Dtype>(ph + 1)
+                                     * bin_size_h));
+    int wend = static_cast<int>(ceil(static_cast<Dtype>(pw + 1)
+                                     * bin_size_w));
+
+    // Add roi offsets and clip to input boundaries
+    hstart = min(max(hstart + roi_start_h, 0), height);
+    hend = min(max(hend + roi_start_h, 0), height);
+    wstart = min(max(wstart + roi_start_w, 0), width);
+    wend = min(max(wend + roi_start_w, 0), width);
+    bool is_empty = (hend <= hstart) || (wend <= wstart);
+
+    // Define an empty pooling region to be zero
+    Dtype maxval = is_empty ? 0 : -FLT_MAX;
+    // If nothing is pooled, argmax = -1 causes nothing to be backprop'd
+    int maxidx = -1;
+    bottom_data += (roi_batch_ind * channels + c) * height * width;
+    for (int h = hstart; h < hend; ++h) {
+      for (int w = wstart; w < wend; ++w) {
+        int bottom_index = h * width + w;
+        if (bottom_data[bottom_index] > maxval) {
+          maxval = bottom_data[bottom_index];
+          maxidx = bottom_index;
+        }
+      }
+    }
+    top_data[index] = maxval;
+    argmax_data[index] = maxidx;
+  }
+}
+
+template <typename Dtype>
+void ROIPoolingLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  const Dtype* bottom_data = bottom[0]->gpu_data();
+  const Dtype* bottom_rois = bottom[1]->gpu_data();
+  Dtype* top_data = top[0]->mutable_gpu_data();
+  int* argmax_data = max_idx_.mutable_gpu_data();
+  int count = top[0]->count();
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  ROIPoolForward<Dtype><<<CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS>>>(
+      count, bottom_data, spatial_scale_, channels_, height_, width_,
+      pooled_height_, pooled_width_, bottom_rois, top_data, argmax_data);
+  CUDA_POST_KERNEL_CHECK;
+}
+
+template <typename Dtype>
+__global__ void ROIPoolBackward(const int nthreads, const Dtype* top_diff,
+    const int* argmax_data, const int num_rois, const Dtype spatial_scale,
+    const int channels, const int height, const int width,
+    const int pooled_height, const int pooled_width, Dtype* bottom_diff,
+    const Dtype* bottom_rois) {
+  CUDA_KERNEL_LOOP(index, nthreads) {
+    // (n, c, h, w) coords in bottom data
+    int w = index % width;
+    int h = (index / width) % height;
+    int c = (index / width / height) % channels;
+    int n = index / width / height / channels;
+
+    Dtype gradient = 0;
+    // Accumulate gradient over all ROIs that pooled this element
+    for (int roi_n = 0; roi_n < num_rois; ++roi_n) {
+      const Dtype* offset_bottom_rois = bottom_rois + roi_n * 5;
+      int roi_batch_ind = offset_bottom_rois[0];
+      // Skip if ROI's batch index doesn't match n
+      if (n != roi_batch_ind) {
+        continue;
+      }
+
+      int roi_start_w = round(offset_bottom_rois[1] * spatial_scale);
+      int roi_start_h = round(offset_bottom_rois[2] * spatial_scale);
+      int roi_end_w = round(offset_bottom_rois[3] * spatial_scale);
+      int roi_end_h = round(offset_bottom_rois[4] * spatial_scale);
+
+      // Skip if ROI doesn't include (h, w)
+      const bool in_roi = (w >= roi_start_w && w <= roi_end_w &&
+                           h >= roi_start_h && h <= roi_end_h);
+      if (!in_roi) {
+        continue;
+      }
+
+      int offset = (roi_n * channels + c) * pooled_height * pooled_width;
+      const Dtype* offset_top_diff = top_diff + offset;
+      const int* offset_argmax_data = argmax_data + offset;
+
+      // Compute feasible set of pooled units that could have pooled
+      // this bottom unit
+
+      // Force malformed ROIs to be 1x1
+      int roi_width = max(roi_end_w - roi_start_w + 1, 1);
+      int roi_height = max(roi_end_h - roi_start_h + 1, 1);
+
+      Dtype bin_size_h = static_cast<Dtype>(roi_height)
+                         / static_cast<Dtype>(pooled_height);
+      Dtype bin_size_w = static_cast<Dtype>(roi_width)
+                         / static_cast<Dtype>(pooled_width);
+
+      int phstart = floor(static_cast<Dtype>(h - roi_start_h) / bin_size_h);
+      int phend = ceil(static_cast<Dtype>(h - roi_start_h + 1) / bin_size_h);
+      int pwstart = floor(static_cast<Dtype>(w - roi_start_w) / bin_size_w);
+      int pwend = ceil(static_cast<Dtype>(w - roi_start_w + 1) / bin_size_w);
+
+      phstart = min(max(phstart, 0), pooled_height);
+      phend = min(max(phend, 0), pooled_height);
+      pwstart = min(max(pwstart, 0), pooled_width);
+      pwend = min(max(pwend, 0), pooled_width);
+
+      for (int ph = phstart; ph < phend; ++ph) {
+        for (int pw = pwstart; pw < pwend; ++pw) {
+          if (offset_argmax_data[ph * pooled_width + pw] == (h * width + w)) {
+            gradient += offset_top_diff[ph * pooled_width + pw];
+          }
+        }
+      }
+    }
+    bottom_diff[index] = gradient;
+  }
+}
+
+template <typename Dtype>
+void ROIPoolingLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+  if (!propagate_down[0]) {
+    return;
+  }
+  const Dtype* bottom_rois = bottom[1]->gpu_data();
+  const Dtype* top_diff = top[0]->gpu_diff();
+  Dtype* bottom_diff = bottom[0]->mutable_gpu_diff();
+  const int count = bottom[0]->count();
+  caffe_gpu_set(count, Dtype(0.), bottom_diff);
+  const int* argmax_data = max_idx_.gpu_data();
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  ROIPoolBackward<Dtype><<<CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS>>>(
+      count, top_diff, argmax_data, top[0]->num(), spatial_scale_, channels_,
+      height_, width_, pooled_height_, pooled_width_, bottom_diff, bottom_rois);
+  CUDA_POST_KERNEL_CHECK;
+}
+
+INSTANTIATE_LAYER_GPU_FUNCS(ROIPoolingLayer);
+
+}  // namespace caffe

--- a/src/caffe/layers/scale_layer.cpp
+++ b/src/caffe/layers/scale_layer.cpp
@@ -97,10 +97,10 @@ void ScaleLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
   scale_dim_ = scale->count();
   inner_dim_ = bottom[0]->count(axis_ + scale->num_axes());
   if (bottom[0] == top[0]) {  // in-place computation
-	  const bool scale_param = (bottom.size() == 1);
-	  if (!scale_param || (scale_param && this->param_propagate_down_[0])) {
-		  temp_.ReshapeLike(*bottom[0]);
-	  }
+    const bool scale_param = (bottom.size() == 1);
+    if (!scale_param || (scale_param && this->param_propagate_down_[0])) {
+      temp_.ReshapeLike(*bottom[0]);
+    }
   } else {
     top[0]->ReshapeLike(*bottom[0]);
   }

--- a/src/caffe/layers/scale_layer.cpp
+++ b/src/caffe/layers/scale_layer.cpp
@@ -97,7 +97,10 @@ void ScaleLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
   scale_dim_ = scale->count();
   inner_dim_ = bottom[0]->count(axis_ + scale->num_axes());
   if (bottom[0] == top[0]) {  // in-place computation
-    temp_.ReshapeLike(*bottom[0]);
+	  const bool scale_param = (bottom.size() == 1);
+	  if (!scale_param || (scale_param && this->param_propagate_down_[0])) {
+		  temp_.ReshapeLike(*bottom[0]);
+	  }
   } else {
     top[0]->ReshapeLike(*bottom[0]);
   }

--- a/src/caffe/layers/scale_layer.cu
+++ b/src/caffe/layers/scale_layer.cu
@@ -36,8 +36,11 @@ void ScaleLayer<Dtype>::Forward_gpu(
     // Note that this is only necessary for Backward; we could skip this if not
     // doing Backward, but Caffe currently provides no way of knowing whether
     // we'll need to do Backward at the time of the Forward call.
-    caffe_copy(bottom[0]->count(), bottom[0]->gpu_data(),
-               temp_.mutable_gpu_data());
+	  const bool scale_param = (bottom.size() == 1);
+	  if (!scale_param || (scale_param && this->param_propagate_down_[0])) {
+		  caffe_copy(bottom[0]->count(), bottom[0]->gpu_data(),
+			  temp_.mutable_gpu_data());
+	  }
   }
   const Dtype* scale_data =
       ((bottom.size() > 1) ? bottom[1] : this->blobs_[0].get())->gpu_data();

--- a/src/caffe/layers/scale_layer.cu
+++ b/src/caffe/layers/scale_layer.cu
@@ -36,11 +36,11 @@ void ScaleLayer<Dtype>::Forward_gpu(
     // Note that this is only necessary for Backward; we could skip this if not
     // doing Backward, but Caffe currently provides no way of knowing whether
     // we'll need to do Backward at the time of the Forward call.
-	  const bool scale_param = (bottom.size() == 1);
-	  if (!scale_param || (scale_param && this->param_propagate_down_[0])) {
-		  caffe_copy(bottom[0]->count(), bottom[0]->gpu_data(),
-			  temp_.mutable_gpu_data());
-	  }
+    const bool scale_param = (bottom.size() == 1);
+    if (!scale_param || (scale_param && this->param_propagate_down_[0])) {
+      caffe_copy(bottom[0]->count(), bottom[0]->gpu_data(),
+        temp_.mutable_gpu_data());
+    }
   }
   const Dtype* scale_data =
       ((bottom.size() > 1) ? bottom[1] : this->blobs_[0].get())->gpu_data();

--- a/src/caffe/layers/smooth_L1_loss_ohem_layer.cpp
+++ b/src/caffe/layers/smooth_L1_loss_ohem_layer.cpp
@@ -1,0 +1,106 @@
+// --------------------------------------------------------
+// R-FCN
+// Written by Yi Li, 2016.
+// --------------------------------------------------------
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "caffe/layers/smooth_l1_loss_ohem_layer.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void SmoothL1LossOHEMLayer<Dtype>::LayerSetUp(
+  const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  has_weights_ = (bottom.size() == 3);
+
+  if (!this->layer_param_.loss_param().has_normalization() &&
+    this->layer_param_.loss_param().has_normalize()) {
+    normalization_ = this->layer_param_.loss_param().normalize() ?
+    LossParameter_NormalizationMode_VALID :
+    LossParameter_NormalizationMode_BATCH_SIZE;
+  }
+  else {
+    normalization_ = this->layer_param_.loss_param().normalization();
+  }
+}
+
+template <typename Dtype>
+void SmoothL1LossOHEMLayer<Dtype>::Reshape(
+  const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  LossLayer<Dtype>::Reshape(bottom, top);
+  CHECK_EQ(bottom[0]->channels(), bottom[1]->channels());
+  CHECK_EQ(bottom[0]->height(), bottom[1]->height());
+  CHECK_EQ(bottom[0]->width(), bottom[1]->width());
+  if (has_weights_) {
+    CHECK_EQ(bottom[0]->channels(), bottom[2]->channels());
+    CHECK_EQ(bottom[0]->height(), bottom[2]->height());
+    CHECK_EQ(bottom[0]->width(), bottom[2]->width());
+  }
+
+  outer_num_ = bottom[0]->num();
+  inner_num_ = bottom[0]->height() * bottom[0]->width();
+
+  diff_.Reshape(bottom[0]->num(), bottom[0]->channels(),
+      bottom[0]->height(), bottom[0]->width());
+  errors_.Reshape(bottom[0]->num(), bottom[0]->channels(),
+      bottom[0]->height(), bottom[0]->width());
+
+  // top[2] stores per-instance loss, which takes the shape of N*1*H*W
+  if (top.size()>=2) {
+    top[1]->Reshape(bottom[0]->num(), 1, bottom[0]->height(), bottom[0]->width());
+  }
+}
+
+template <typename Dtype>
+Dtype SmoothL1LossOHEMLayer<Dtype>::get_normalizer(
+  LossParameter_NormalizationMode normalization_mode, Dtype pre_fixed_normalizer) {
+  Dtype normalizer;
+  switch (normalization_mode) {
+  case LossParameter_NormalizationMode_FULL:
+    normalizer = Dtype(outer_num_ * inner_num_);
+    break;
+  case LossParameter_NormalizationMode_VALID:
+    normalizer = Dtype(outer_num_ * inner_num_);
+    break;
+  case LossParameter_NormalizationMode_BATCH_SIZE:
+    normalizer = Dtype(outer_num_);
+    break;
+  case LossParameter_NormalizationMode_PRE_FIXED:
+    normalizer = pre_fixed_normalizer;
+    break;
+  case LossParameter_NormalizationMode_NONE:
+    normalizer = Dtype(1);
+    break;
+  default:
+    LOG(FATAL) << "Unknown normalization mode: "
+      << LossParameter_NormalizationMode_Name(normalization_mode);
+  }
+  // Some users will have no labels for some examples in order to 'turn off' a
+  // particular loss in a multi-task setup. The max prevents NaNs in that case.
+  return std::max(Dtype(1.0), normalizer);
+}
+
+template <typename Dtype>
+void SmoothL1LossOHEMLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  NOT_IMPLEMENTED;
+}
+
+template <typename Dtype>
+void SmoothL1LossOHEMLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+  NOT_IMPLEMENTED;
+}
+
+#ifdef CPU_ONLY
+STUB_GPU(SmoothL1LossOHEMLayer);
+#endif
+
+INSTANTIATE_CLASS(SmoothL1LossOHEMLayer);
+REGISTER_LAYER_CLASS(SmoothL1LossOHEM);
+
+}  // namespace caffe

--- a/src/caffe/layers/smooth_L1_loss_ohem_layer.cpp
+++ b/src/caffe/layers/smooth_L1_loss_ohem_layer.cpp
@@ -3,6 +3,7 @@
 // Written by Yi Li, 2016.
 // --------------------------------------------------------
 
+#include <algorithm>
 #include <string>
 #include <utility>
 #include <vector>
@@ -22,8 +23,7 @@ void SmoothL1LossOHEMLayer<Dtype>::LayerSetUp(
     normalization_ = this->layer_param_.loss_param().normalize() ?
     LossParameter_NormalizationMode_VALID :
     LossParameter_NormalizationMode_BATCH_SIZE;
-  }
-  else {
+  } else {
     normalization_ = this->layer_param_.loss_param().normalization();
   }
 }
@@ -50,14 +50,16 @@ void SmoothL1LossOHEMLayer<Dtype>::Reshape(
       bottom[0]->height(), bottom[0]->width());
 
   // top[2] stores per-instance loss, which takes the shape of N*1*H*W
-  if (top.size()>=2) {
-    top[1]->Reshape(bottom[0]->num(), 1, bottom[0]->height(), bottom[0]->width());
+  if (top.size() >= 2) {
+    top[1]->Reshape(
+      bottom[0]->num(), 1, bottom[0]->height(), bottom[0]->width());
   }
 }
 
 template <typename Dtype>
 Dtype SmoothL1LossOHEMLayer<Dtype>::get_normalizer(
-  LossParameter_NormalizationMode normalization_mode, Dtype pre_fixed_normalizer) {
+  LossParameter_NormalizationMode normalization_mode,
+  Dtype pre_fixed_normalizer) {
   Dtype normalizer;
   switch (normalization_mode) {
   case LossParameter_NormalizationMode_FULL:
@@ -85,14 +87,15 @@ Dtype SmoothL1LossOHEMLayer<Dtype>::get_normalizer(
 }
 
 template <typename Dtype>
-void SmoothL1LossOHEMLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
-    const vector<Blob<Dtype>*>& top) {
+void SmoothL1LossOHEMLayer<Dtype>::Forward_cpu(
+    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
   NOT_IMPLEMENTED;
 }
 
 template <typename Dtype>
-void SmoothL1LossOHEMLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
-    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+void SmoothL1LossOHEMLayer<Dtype>::Backward_cpu(
+  const vector<Blob<Dtype>*>& top, const vector<bool>& propagate_down,
+  const vector<Blob<Dtype>*>& bottom) {
   NOT_IMPLEMENTED;
 }
 

--- a/src/caffe/layers/smooth_L1_loss_ohem_layer.cu
+++ b/src/caffe/layers/smooth_L1_loss_ohem_layer.cu
@@ -1,0 +1,127 @@
+// --------------------------------------------------------
+// R-FCN
+// Written by Yi Li, 2016.
+// --------------------------------------------------------
+
+#include <algorithm>
+#include <cfloat>
+#include <vector>
+
+#include "thrust/device_vector.h"
+
+#include "caffe/layers/smooth_l1_loss_ohem_layer.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+	template <typename Dtype>
+	__global__ void SmoothL1ForwardGPU(const int n, const Dtype* in, Dtype* out) {
+		// f(x) = 0.5 * x^2    if |x| < 1
+		//        |x| - 0.5    otherwise
+		CUDA_KERNEL_LOOP(index, n) {
+			Dtype val = in[index];
+			Dtype abs_val = abs(val);
+			if (abs_val < 1) {
+				out[index] = 0.5 * val * val;
+			}
+			else {
+				out[index] = abs_val - 0.5;
+			}
+		}
+	}
+
+  template <typename Dtype>
+  __global__ void kernel_channel_sum(const int num, const int channels,
+    const int spatial_dim, const Dtype* data, Dtype* channel_sum) {
+    CUDA_KERNEL_LOOP(index, num * spatial_dim) {
+      int n = index / spatial_dim;
+      int s = index % spatial_dim;
+      Dtype sum = 0;
+      for (int c = 0; c < channels; ++c) {
+        sum += data[(n * channels + c) * spatial_dim + s];
+      }
+      channel_sum[index] = sum;
+    }
+  }
+
+	template <typename Dtype>
+	void SmoothL1LossOHEMLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+		const vector<Blob<Dtype>*>& top) {
+		int count = bottom[0]->count();
+		caffe_gpu_sub(
+			count,
+			bottom[0]->gpu_data(),
+			bottom[1]->gpu_data(),
+			diff_.mutable_gpu_data());    // d := b0 - b1
+		if (has_weights_) {
+			caffe_gpu_mul(
+				count,
+				bottom[2]->gpu_data(),
+				diff_.gpu_data(),
+				diff_.mutable_gpu_data());  // d := w * (b0 - b1)
+		}
+		SmoothL1ForwardGPU<Dtype> << <CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS >> >(
+			count, diff_.gpu_data(), errors_.mutable_gpu_data());
+		CUDA_POST_KERNEL_CHECK;
+
+		
+		Dtype loss;
+		caffe_gpu_asum(count, errors_.gpu_data(), &loss);
+		int spatial_dim = diff_.height() * diff_.width();
+
+		Dtype pre_fixed_normalizer = this->layer_param_.loss_param().pre_fixed_normalizer();
+		top[0]->mutable_cpu_data()[0] = loss / get_normalizer(normalization_,
+			pre_fixed_normalizer);
+
+		// Output per-instance loss
+    if (top.size() >= 2) {
+      kernel_channel_sum<Dtype> << <CAFFE_GET_BLOCKS(top[0]->count()), CAFFE_CUDA_NUM_THREADS >> >
+        (outer_num_, bottom[0]->channels(), inner_num_, errors_.gpu_data(),
+          top[1]->mutable_gpu_data());
+    }
+	}
+
+	template <typename Dtype>
+	__global__ void SmoothL1BackwardGPU(const int n, const Dtype* in, Dtype* out) {
+		// f'(x) = x         if |x| < 1
+		//       = sign(x)   otherwise
+		CUDA_KERNEL_LOOP(index, n) {
+			Dtype val = in[index];
+			Dtype abs_val = abs(val);
+			if (abs_val < 1) {
+				out[index] = val;
+			}
+			else {
+				out[index] = (Dtype(0) < val) - (val < Dtype(0));
+			}
+		}
+	}
+
+	template <typename Dtype>
+	void SmoothL1LossOHEMLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
+		const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+		int count = diff_.count();
+		SmoothL1BackwardGPU<Dtype> << <CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS >> >(
+			count, diff_.gpu_data(), diff_.mutable_gpu_data());
+		CUDA_POST_KERNEL_CHECK;
+		for (int i = 0; i < 2; ++i) {
+			if (propagate_down[i]) {
+				const Dtype sign = (i == 0) ? 1 : -1;
+				int spatial_dim = diff_.height() * diff_.width();
+
+				Dtype pre_fixed_normalizer = this->layer_param_.loss_param().pre_fixed_normalizer();
+				Dtype normalizer =  get_normalizer(normalization_, pre_fixed_normalizer);
+				Dtype alpha = sign * top[0]->cpu_diff()[0] / normalizer;
+
+				caffe_gpu_axpby(
+					bottom[i]->count(),              // count
+					alpha,                           // alpha
+					diff_.gpu_data(),                // x
+					Dtype(0),                        // beta
+					bottom[i]->mutable_gpu_diff());  // y
+			}
+		}
+	}
+
+	INSTANTIATE_LAYER_GPU_FUNCS(SmoothL1LossOHEMLayer);
+
+}  // namespace caffe

--- a/src/caffe/layers/smooth_L1_loss_ohem_layer.cu
+++ b/src/caffe/layers/smooth_L1_loss_ohem_layer.cu
@@ -13,21 +13,20 @@
 #include "caffe/util/math_functions.hpp"
 
 namespace caffe {
-	template <typename Dtype>
-	__global__ void SmoothL1ForwardGPU(const int n, const Dtype* in, Dtype* out) {
-		// f(x) = 0.5 * x^2    if |x| < 1
-		//        |x| - 0.5    otherwise
-		CUDA_KERNEL_LOOP(index, n) {
-			Dtype val = in[index];
-			Dtype abs_val = abs(val);
-			if (abs_val < 1) {
-				out[index] = 0.5 * val * val;
-			}
-			else {
-				out[index] = abs_val - 0.5;
-			}
-		}
-	}
+  template <typename Dtype>
+  __global__ void SmoothL1ForwardGPU(const int n, const Dtype* in, Dtype* out) {
+    // f(x) = 0.5 * x^2    if |x| < 1
+    //        |x| - 0.5    otherwise
+    CUDA_KERNEL_LOOP(index, n) {
+      Dtype val = in[index];
+      Dtype abs_val = abs(val);
+      if (abs_val < 1) {
+        out[index] = 0.5 * val * val;
+      } else {
+        out[index] = abs_val - 0.5;
+      }
+    }
+  }
 
   template <typename Dtype>
   __global__ void kernel_channel_sum(const int num, const int channels,
@@ -43,36 +42,38 @@ namespace caffe {
     }
   }
 
-	template <typename Dtype>
-	void SmoothL1LossOHEMLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
-		const vector<Blob<Dtype>*>& top) {
-		int count = bottom[0]->count();
-		caffe_gpu_sub(
-			count,
-			bottom[0]->gpu_data(),
-			bottom[1]->gpu_data(),
-			diff_.mutable_gpu_data());    // d := b0 - b1
-		if (has_weights_) {
-			caffe_gpu_mul(
-				count,
-				bottom[2]->gpu_data(),
-				diff_.gpu_data(),
-				diff_.mutable_gpu_data());  // d := w * (b0 - b1)
-		}
-		SmoothL1ForwardGPU<Dtype> << <CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS >> >(
-			count, diff_.gpu_data(), errors_.mutable_gpu_data());
-		CUDA_POST_KERNEL_CHECK;
+  template <typename Dtype>
+  void SmoothL1LossOHEMLayer<Dtype>::Forward_gpu(
+    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+    int count = bottom[0]->count();
+    caffe_gpu_sub(
+      count,
+      bottom[0]->gpu_data(),
+      bottom[1]->gpu_data(),
+      diff_.mutable_gpu_data());    // d := b0 - b1
+    if (has_weights_) {
+      caffe_gpu_mul(
+        count,
+        bottom[2]->gpu_data(),
+        diff_.gpu_data(),
+        diff_.mutable_gpu_data());  // d := w * (b0 - b1)
+    }
+    SmoothL1ForwardGPU<Dtype> << <CAFFE_GET_BLOCKS(count),
+      CAFFE_CUDA_NUM_THREADS >> >(count, diff_.gpu_data(),
+      errors_.mutable_gpu_data());
+    CUDA_POST_KERNEL_CHECK;
 
-		
-		Dtype loss;
-		caffe_gpu_asum(count, errors_.gpu_data(), &loss);
-		int spatial_dim = diff_.height() * diff_.width();
 
-		Dtype pre_fixed_normalizer = this->layer_param_.loss_param().pre_fixed_normalizer();
-		top[0]->mutable_cpu_data()[0] = loss / get_normalizer(normalization_,
-			pre_fixed_normalizer);
+    Dtype loss;
+    caffe_gpu_asum(count, errors_.gpu_data(), &loss);
+    int spatial_dim = diff_.height() * diff_.width();
 
-		// Output per-instance loss
+    Dtype pre_fixed_normalizer =
+      this->layer_param_.loss_param().pre_fixed_normalizer();
+    top[0]->mutable_cpu_data()[0] = loss / get_normalizer(normalization_,
+      pre_fixed_normalizer);
+
+    // Output per-instance loss
     if (top.size() >= 2) {
       kernel_channel_sum<Dtype> << <CAFFE_GET_BLOCKS(top[1]->count()),
         CAFFE_CUDA_NUM_THREADS >> > (outer_num_, bottom[0]->channels(),
@@ -122,52 +123,13 @@ namespace caffe {
           Dtype(0),                        // beta
           bottom[i]->mutable_gpu_diff());  // y
       }
+<<<<<<< HEAD
 >>>>>>> 66d73988... Fix test issues
+=======
+>>>>>>> d5f5bd5d... Fix code format issues
     }
-	}
+  }
 
-	template <typename Dtype>
-	__global__ void SmoothL1BackwardGPU(const int n, const Dtype* in, Dtype* out) {
-		// f'(x) = x         if |x| < 1
-		//       = sign(x)   otherwise
-		CUDA_KERNEL_LOOP(index, n) {
-			Dtype val = in[index];
-			Dtype abs_val = abs(val);
-			if (abs_val < 1) {
-				out[index] = val;
-			}
-			else {
-				out[index] = (Dtype(0) < val) - (val < Dtype(0));
-			}
-		}
-	}
-
-	template <typename Dtype>
-	void SmoothL1LossOHEMLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
-		const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
-		int count = diff_.count();
-		SmoothL1BackwardGPU<Dtype> << <CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS >> >(
-			count, diff_.gpu_data(), diff_.mutable_gpu_data());
-		CUDA_POST_KERNEL_CHECK;
-		for (int i = 0; i < 2; ++i) {
-			if (propagate_down[i]) {
-				const Dtype sign = (i == 0) ? 1 : -1;
-				int spatial_dim = diff_.height() * diff_.width();
-
-				Dtype pre_fixed_normalizer = this->layer_param_.loss_param().pre_fixed_normalizer();
-				Dtype normalizer =  get_normalizer(normalization_, pre_fixed_normalizer);
-				Dtype alpha = sign * top[0]->cpu_diff()[0] / normalizer;
-
-				caffe_gpu_axpby(
-					bottom[i]->count(),              // count
-					alpha,                           // alpha
-					diff_.gpu_data(),                // x
-					Dtype(0),                        // beta
-					bottom[i]->mutable_gpu_diff());  // y
-			}
-		}
-	}
-
-	INSTANTIATE_LAYER_GPU_FUNCS(SmoothL1LossOHEMLayer);
+  INSTANTIATE_LAYER_GPU_FUNCS(SmoothL1LossOHEMLayer);
 
 }  // namespace caffe

--- a/src/caffe/layers/smooth_l1_loss_layer.cpp
+++ b/src/caffe/layers/smooth_l1_loss_layer.cpp
@@ -1,0 +1,65 @@
+#include <vector>
+
+#include "caffe/layers/smooth_l1_loss_layer.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void SmoothL1LossLayer<Dtype>::LayerSetUp(
+  const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  SmoothL1LossParameter loss_param = this->layer_param_.smooth_l1_loss_param();
+  sigma2_ = loss_param.sigma() * loss_param.sigma();
+  has_weights_ = (bottom.size() >= 3);
+  if (has_weights_) {
+    CHECK_EQ(bottom.size(), 4) << "If weights are used, must specify both "
+      "inside and outside weights";
+  }
+}
+
+template <typename Dtype>
+void SmoothL1LossLayer<Dtype>::Reshape(
+  const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  LossLayer<Dtype>::Reshape(bottom, top);
+  CHECK_EQ(bottom[0]->channels(), bottom[1]->channels());
+  CHECK_EQ(bottom[0]->height(), bottom[1]->height());
+  CHECK_EQ(bottom[0]->width(), bottom[1]->width());
+  if (has_weights_) {
+    CHECK_EQ(bottom[0]->channels(), bottom[2]->channels());
+    CHECK_EQ(bottom[0]->height(), bottom[2]->height());
+    CHECK_EQ(bottom[0]->width(), bottom[2]->width());
+    CHECK_EQ(bottom[0]->channels(), bottom[3]->channels());
+    CHECK_EQ(bottom[0]->height(), bottom[3]->height());
+    CHECK_EQ(bottom[0]->width(), bottom[3]->width());
+  }
+  diff_.Reshape(bottom[0]->num(), bottom[0]->channels(),
+      bottom[0]->height(), bottom[0]->width());
+  errors_.Reshape(bottom[0]->num(), bottom[0]->channels(),
+      bottom[0]->height(), bottom[0]->width());
+  // vector of ones used to sum
+  ones_.Reshape(bottom[0]->num(), bottom[0]->channels(),
+      bottom[0]->height(), bottom[0]->width());
+  for (int i = 0; i < bottom[0]->count(); ++i) {
+    ones_.mutable_cpu_data()[i] = Dtype(1);
+  }
+}
+
+template <typename Dtype>
+void SmoothL1LossLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  NOT_IMPLEMENTED;
+}
+
+template <typename Dtype>
+void SmoothL1LossLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+  NOT_IMPLEMENTED;
+}
+
+#ifdef CPU_ONLY
+STUB_GPU(SmoothL1LossLayer);
+#endif
+
+INSTANTIATE_CLASS(SmoothL1LossLayer);
+REGISTER_LAYER_CLASS(SmoothL1Loss);
+
+}  // namespace caffe

--- a/src/caffe/layers/smooth_l1_loss_layer.cu
+++ b/src/caffe/layers/smooth_l1_loss_layer.cu
@@ -1,0 +1,116 @@
+#include <vector>
+
+#include "caffe/layers/smooth_l1_loss_layer.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+__global__ void SmoothL1Forward(const int n, const Dtype* in, Dtype* out,
+    Dtype sigma2) {
+  // f(x) = 0.5 * (sigma * x)^2          if |x| < 1 / sigma / sigma
+  //        |x| - 0.5 / sigma / sigma    otherwise
+  CUDA_KERNEL_LOOP(index, n) {
+    Dtype val = in[index];
+    Dtype abs_val = abs(val);
+    if (abs_val < 1.0 / sigma2) {
+      out[index] = 0.5 * val * val * sigma2;
+    } else {
+      out[index] = abs_val - 0.5 / sigma2;
+    }
+  }
+}
+
+template <typename Dtype>
+void SmoothL1LossLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  int count = bottom[0]->count();
+  caffe_gpu_sub(
+      count,
+      bottom[0]->gpu_data(),
+      bottom[1]->gpu_data(),
+      diff_.mutable_gpu_data());    // d := b0 - b1
+  if (has_weights_) {
+    // apply "inside" weights
+    caffe_gpu_mul(
+        count,
+        bottom[2]->gpu_data(),
+        diff_.gpu_data(),
+        diff_.mutable_gpu_data());  // d := w_in * (b0 - b1)
+  }
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  SmoothL1Forward<Dtype><<<CAFFE_GET_BLOCKS(count),
+    CAFFE_CUDA_NUM_THREADS>>>(
+      count, diff_.gpu_data(), errors_.mutable_gpu_data(), sigma2_);
+  CUDA_POST_KERNEL_CHECK;
+
+  if (has_weights_) {
+    // apply "outside" weights
+    caffe_gpu_mul(
+        count,
+        bottom[3]->gpu_data(),
+        errors_.gpu_data(),
+        errors_.mutable_gpu_data());  // d := w_out * SmoothL1(w_in * (b0 - b1))
+  }
+
+  Dtype loss;
+  caffe_gpu_dot(count, ones_.gpu_data(), errors_.gpu_data(), &loss);
+  top[0]->mutable_cpu_data()[0] = loss / bottom[0]->num();
+}
+
+template <typename Dtype>
+__global__ void SmoothL1Backward(const int n, const Dtype* in, Dtype* out,
+    Dtype sigma2) {
+  // f'(x) = sigma * sigma * x         if |x| < 1 / sigma / sigma
+  //       = sign(x)                   otherwise
+  CUDA_KERNEL_LOOP(index, n) {
+    Dtype val = in[index];
+    Dtype abs_val = abs(val);
+    if (abs_val < 1.0 / sigma2) {
+      out[index] = sigma2 * val;
+    } else {
+      out[index] = (Dtype(0) < val) - (val < Dtype(0));
+    }
+  }
+}
+
+template <typename Dtype>
+void SmoothL1LossLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+  // after forwards, diff_ holds w_in * (b0 - b1)
+  int count = diff_.count();
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  SmoothL1Backward<Dtype><<<CAFFE_GET_BLOCKS(count),
+    CAFFE_CUDA_NUM_THREADS >>>(
+      count, diff_.gpu_data(), diff_.mutable_gpu_data(), sigma2_);
+  CUDA_POST_KERNEL_CHECK;
+  for (int i = 0; i < 2; ++i) {
+    if (propagate_down[i]) {
+      const Dtype sign = (i == 0) ? 1 : -1;
+      const Dtype alpha = sign * top[0]->cpu_diff()[0] / bottom[i]->num();
+      caffe_gpu_axpby(
+          count,                           // count
+          alpha,                           // alpha
+          diff_.gpu_data(),                // x
+          Dtype(0),                        // beta
+          bottom[i]->mutable_gpu_diff());  // y
+      if (has_weights_) {
+        // Scale by "inside" weight
+        caffe_gpu_mul(
+            count,
+            bottom[2]->gpu_data(),
+            bottom[i]->gpu_diff(),
+            bottom[i]->mutable_gpu_diff());
+        // Scale by "outside" weight
+        caffe_gpu_mul(
+            count,
+            bottom[3]->gpu_data(),
+            bottom[i]->gpu_diff(),
+            bottom[i]->mutable_gpu_diff());
+      }
+    }
+  }
+}
+
+INSTANTIATE_LAYER_GPU_FUNCS(SmoothL1LossLayer);
+
+}  // namespace caffe

--- a/src/caffe/layers/softmax_loss_ohem_layer.cpp
+++ b/src/caffe/layers/softmax_loss_ohem_layer.cpp
@@ -11,9 +11,9 @@ template <typename Dtype>
 void SoftmaxWithLossOHEMLayer<Dtype>::LayerSetUp(
     const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
   LossLayer<Dtype>::LayerSetUp(bottom, top);
-	LayerParameter softmax_param(this->layer_param_);
-	// Fix a bug which occurs with more than one output
-	softmax_param.clear_loss_weight();
+  LayerParameter softmax_param(this->layer_param_);
+  // Fix a bug which occurs with more than one output
+  softmax_param.clear_loss_weight();
   softmax_param.set_type("Softmax");
   softmax_layer_ = LayerRegistry<Dtype>::CreateLayer(softmax_param);
   softmax_bottom_vec_.clear();
@@ -56,10 +56,10 @@ void SoftmaxWithLossOHEMLayer<Dtype>::Reshape(
     top[1]->ReshapeLike(*bottom[0]);
   }
 
-	// top[2] stores per-instance loss, which takes the shape of N*1*H*W
+  // top[2] stores per-instance loss, which takes the shape of N*1*H*W
   if (top.size() >= 3) {
-		top[2]->ReshapeLike(*bottom[1]);
-	}
+    top[2]->ReshapeLike(*bottom[1]);
+  }
 }
 
 template <typename Dtype>
@@ -95,13 +95,14 @@ Dtype SoftmaxWithLossOHEMLayer<Dtype>::get_normalizer(
 template <typename Dtype>
 void SoftmaxWithLossOHEMLayer<Dtype>::Forward_cpu(
     const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
-	NOT_IMPLEMENTED;
+  NOT_IMPLEMENTED;
 }
 
 template <typename Dtype>
-void SoftmaxWithLossOHEMLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
-    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
-	NOT_IMPLEMENTED;
+void SoftmaxWithLossOHEMLayer<Dtype>::Backward_cpu(
+  const vector<Blob<Dtype>*>& top, const vector<bool>& propagate_down,
+  const vector<Blob<Dtype>*>& bottom) {
+  NOT_IMPLEMENTED;
 }
 
 #ifdef CPU_ONLY

--- a/src/caffe/layers/softmax_loss_ohem_layer.cpp
+++ b/src/caffe/layers/softmax_loss_ohem_layer.cpp
@@ -1,0 +1,114 @@
+#include <algorithm>
+#include <cfloat>
+#include <vector>
+
+#include "caffe/layers/softmax_loss_ohem_layer.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void SoftmaxWithLossOHEMLayer<Dtype>::LayerSetUp(
+    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  LossLayer<Dtype>::LayerSetUp(bottom, top);
+	LayerParameter softmax_param(this->layer_param_);
+	// Fix a bug which occurs with more than one output
+	softmax_param.clear_loss_weight();
+  softmax_param.set_type("Softmax");
+  softmax_layer_ = LayerRegistry<Dtype>::CreateLayer(softmax_param);
+  softmax_bottom_vec_.clear();
+  softmax_bottom_vec_.push_back(bottom[0]);
+  softmax_top_vec_.clear();
+  softmax_top_vec_.push_back(&prob_);
+  softmax_layer_->SetUp(softmax_bottom_vec_, softmax_top_vec_);
+
+  has_ignore_label_ =
+    this->layer_param_.loss_param().has_ignore_label();
+  if (has_ignore_label_) {
+    ignore_label_ = this->layer_param_.loss_param().ignore_label();
+  }
+  if (!this->layer_param_.loss_param().has_normalization() &&
+      this->layer_param_.loss_param().has_normalize()) {
+    normalization_ = this->layer_param_.loss_param().normalize() ?
+                     LossParameter_NormalizationMode_VALID :
+                     LossParameter_NormalizationMode_BATCH_SIZE;
+  } else {
+    normalization_ = this->layer_param_.loss_param().normalization();
+  }
+}
+
+template <typename Dtype>
+void SoftmaxWithLossOHEMLayer<Dtype>::Reshape(
+    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  LossLayer<Dtype>::Reshape(bottom, top);
+  softmax_layer_->Reshape(softmax_bottom_vec_, softmax_top_vec_);
+  softmax_axis_ =
+      bottom[0]->CanonicalAxisIndex(this->layer_param_.softmax_param().axis());
+  outer_num_ = bottom[0]->count(0, softmax_axis_);
+  inner_num_ = bottom[0]->count(softmax_axis_ + 1);
+  CHECK_EQ(outer_num_ * inner_num_, bottom[1]->count())
+      << "Number of labels must match number of predictions; "
+      << "e.g., if softmax axis == 1 and prediction shape is (N, C, H, W), "
+      << "label count (number of labels) must be N*H*W, "
+      << "with integer values in {0, 1, ..., C-1}.";
+  if (top.size() >= 2) {
+    // softmax output
+    top[1]->ReshapeLike(*bottom[0]);
+  }
+
+	// top[2] stores per-instance loss, which takes the shape of N*1*H*W
+  if (top.size() >= 3) {
+		top[2]->ReshapeLike(*bottom[1]);
+	}
+}
+
+template <typename Dtype>
+Dtype SoftmaxWithLossOHEMLayer<Dtype>::get_normalizer(
+    LossParameter_NormalizationMode normalization_mode, int valid_count) {
+  Dtype normalizer;
+  switch (normalization_mode) {
+    case LossParameter_NormalizationMode_FULL:
+      normalizer = Dtype(outer_num_ * inner_num_);
+      break;
+    case LossParameter_NormalizationMode_VALID:
+      if (valid_count == -1) {
+        normalizer = Dtype(outer_num_ * inner_num_);
+      } else {
+        normalizer = Dtype(valid_count);
+      }
+      break;
+    case LossParameter_NormalizationMode_BATCH_SIZE:
+      normalizer = Dtype(outer_num_);
+      break;
+    case LossParameter_NormalizationMode_NONE:
+      normalizer = Dtype(1);
+      break;
+    default:
+      LOG(FATAL) << "Unknown normalization mode: "
+          << LossParameter_NormalizationMode_Name(normalization_mode);
+  }
+  // Some users will have no labels for some examples in order to 'turn off' a
+  // particular loss in a multi-task setup. The max prevents NaNs in that case.
+  return std::max(Dtype(1.0), normalizer);
+}
+
+template <typename Dtype>
+void SoftmaxWithLossOHEMLayer<Dtype>::Forward_cpu(
+    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+	NOT_IMPLEMENTED;
+}
+
+template <typename Dtype>
+void SoftmaxWithLossOHEMLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+	NOT_IMPLEMENTED;
+}
+
+#ifdef CPU_ONLY
+STUB_GPU(SoftmaxWithLossOHEMLayer);
+#endif
+
+INSTANTIATE_CLASS(SoftmaxWithLossOHEMLayer);
+REGISTER_LAYER_CLASS(SoftmaxWithLossOHEM);
+
+}  // namespace caffe

--- a/src/caffe/layers/softmax_loss_ohem_layer.cu
+++ b/src/caffe/layers/softmax_loss_ohem_layer.cu
@@ -1,0 +1,136 @@
+#include <algorithm>
+#include <cfloat>
+#include <vector>
+
+#include "caffe/layers/softmax_loss_ohem_layer.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+__global__ void SoftmaxLossForwardGPU(const int nthreads,
+          const Dtype* prob_data, const Dtype* label, Dtype* loss,
+          const int num, const int dim, const int spatial_dim,
+          const bool has_ignore_label_, const int ignore_label_,
+          Dtype* counts) {
+  CUDA_KERNEL_LOOP(index, nthreads) {
+    const int n = index / spatial_dim;
+    const int s = index % spatial_dim;
+    const int label_value = static_cast<int>(label[n * spatial_dim + s]);
+    if (has_ignore_label_ && label_value == ignore_label_) {
+      loss[index] = 0;
+      counts[index] = 0;
+    } else {
+      loss[index] = -log(max(prob_data[n * dim + label_value * spatial_dim + s],
+                      Dtype(FLT_MIN)));
+      counts[index] = 1;
+    }
+  }
+}
+
+template <typename Dtype>
+void SoftmaxWithLossOHEMLayer<Dtype>::Forward_gpu(
+    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  softmax_layer_->Forward(softmax_bottom_vec_, softmax_top_vec_);
+  const Dtype* prob_data = prob_.gpu_data();
+  const Dtype* label = bottom[1]->gpu_data();
+  const int dim = prob_.count() / outer_num_;
+  const int nthreads = outer_num_ * inner_num_;
+  // Since this memory is not used for anything until it is overwritten
+  // on the backward pass, we use it here to avoid having to allocate new GPU
+  // memory to accumulate intermediate results in the kernel.
+  Dtype* loss_data = bottom[0]->mutable_gpu_diff();
+  // Similarly, this memory is never used elsewhere, and thus we can use it
+  // to avoid having to allocate additional GPU memory.
+  Dtype* counts = prob_.mutable_gpu_diff();
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  SoftmaxLossForwardGPU<Dtype><<<CAFFE_GET_BLOCKS(nthreads),
+      CAFFE_CUDA_NUM_THREADS>>>(nthreads, prob_data, label, loss_data,
+      outer_num_, dim, inner_num_, has_ignore_label_, ignore_label_, counts);
+  Dtype loss;
+  caffe_gpu_asum(nthreads, loss_data, &loss);
+  Dtype valid_count = -1;
+  // Only launch another CUDA kernel if we actually need the count of valid
+  // outputs.
+  if (normalization_ == LossParameter_NormalizationMode_VALID &&
+      has_ignore_label_) {
+    caffe_gpu_asum(nthreads, counts, &valid_count);
+  }
+  top[0]->mutable_cpu_data()[0] = loss / get_normalizer(normalization_,
+                                                        valid_count);
+  if (top.size() >= 2) {
+    top[1]->ShareData(prob_);
+  }
+  if (top.size() >= 3) {
+		// Output per-instance loss
+    caffe_gpu_memcpy(top[2]->count() * sizeof(Dtype), loss_data, top[2]->mutable_gpu_data());
+  }
+
+	// Fix a bug, which happens when propagate_down[0] = false in backward
+	caffe_gpu_set(bottom[0]->count(), Dtype(0), bottom[0]->mutable_gpu_diff());
+}
+
+template <typename Dtype>
+__global__ void SoftmaxLossBackwardGPU(const int nthreads, const Dtype* top,
+          const Dtype* label, Dtype* bottom_diff, const int num, const int dim,
+          const int spatial_dim, const bool has_ignore_label_,
+          const int ignore_label_, Dtype* counts) {
+  const int channels = dim / spatial_dim;
+
+  CUDA_KERNEL_LOOP(index, nthreads) {
+    const int n = index / spatial_dim;
+    const int s = index % spatial_dim;
+    const int label_value = static_cast<int>(label[n * spatial_dim + s]);
+
+    if (has_ignore_label_ && label_value == ignore_label_) {
+      for (int c = 0; c < channels; ++c) {
+        bottom_diff[n * dim + c * spatial_dim + s] = 0;
+      }
+      counts[index] = 0;
+    } else {
+      bottom_diff[n * dim + label_value * spatial_dim + s] -= 1;
+      counts[index] = 1;
+    }
+  }
+}
+
+template <typename Dtype>
+void SoftmaxWithLossOHEMLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+
+  if (propagate_down[1]) {
+    LOG(FATAL) << this->type()
+               << " Layer cannot backpropagate to label inputs.";
+  }
+  if (propagate_down[0]) {
+    Dtype* bottom_diff = bottom[0]->mutable_gpu_diff();
+    const Dtype* prob_data = prob_.gpu_data();
+    const Dtype* top_data = top[0]->gpu_data();
+    caffe_gpu_memcpy(prob_.count() * sizeof(Dtype), prob_data, bottom_diff);
+    const Dtype* label = bottom[1]->gpu_data();
+    const int dim = prob_.count() / outer_num_;
+    const int nthreads = outer_num_ * inner_num_;
+    // Since this memory is never used for anything else,
+    // we use to to avoid allocating new GPU memory.
+    Dtype* counts = prob_.mutable_gpu_diff();
+    // NOLINT_NEXT_LINE(whitespace/operators)
+    SoftmaxLossBackwardGPU<Dtype><<<CAFFE_GET_BLOCKS(nthreads),
+        CAFFE_CUDA_NUM_THREADS>>>(nthreads, top_data, label, bottom_diff,
+        outer_num_, dim, inner_num_, has_ignore_label_, ignore_label_, counts);
+
+    Dtype valid_count = -1;
+    // Only launch another CUDA kernel if we actually need the count of valid
+    // outputs.
+    if (normalization_ == LossParameter_NormalizationMode_VALID &&
+        has_ignore_label_) {
+      caffe_gpu_asum(nthreads, counts, &valid_count);
+    }
+    const Dtype loss_weight = top[0]->cpu_diff()[0] /
+                              get_normalizer(normalization_, valid_count);
+    caffe_gpu_scal(prob_.count(), loss_weight , bottom_diff);
+  }
+}
+
+INSTANTIATE_LAYER_GPU_FUNCS(SoftmaxWithLossOHEMLayer);
+
+}  // namespace caffe

--- a/src/caffe/layers/softmax_loss_ohem_layer.cu
+++ b/src/caffe/layers/softmax_loss_ohem_layer.cu
@@ -62,12 +62,13 @@ void SoftmaxWithLossOHEMLayer<Dtype>::Forward_gpu(
     top[1]->ShareData(prob_);
   }
   if (top.size() >= 3) {
-		// Output per-instance loss
-    caffe_gpu_memcpy(top[2]->count() * sizeof(Dtype), loss_data, top[2]->mutable_gpu_data());
+    // Output per-instance loss
+    caffe_gpu_memcpy(top[2]->count() * sizeof(Dtype), loss_data,
+      top[2]->mutable_gpu_data());
   }
 
-	// Fix a bug, which happens when propagate_down[0] = false in backward
-	caffe_gpu_set(bottom[0]->count(), Dtype(0), bottom[0]->mutable_gpu_diff());
+  // Fix a bug, which happens when propagate_down[0] = false in backward
+  caffe_gpu_set(bottom[0]->count(), Dtype(0), bottom[0]->mutable_gpu_diff());
 }
 
 template <typename Dtype>
@@ -95,9 +96,9 @@ __global__ void SoftmaxLossBackwardGPU(const int nthreads, const Dtype* top,
 }
 
 template <typename Dtype>
-void SoftmaxWithLossOHEMLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
-    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
-
+void SoftmaxWithLossOHEMLayer<Dtype>::Backward_gpu(
+  const vector<Blob<Dtype>*>& top, const vector<bool>& propagate_down,
+  const vector<Blob<Dtype>*>& bottom) {
   if (propagate_down[1]) {
     LOG(FATAL) << this->type()
                << " Layer cannot backpropagate to label inputs.";

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -256,9 +256,9 @@ void Net<Dtype>::Init(const NetParameter& in_param) {
 }
 
 template <typename Dtype>
-void Net<Dtype>::SetPhase(Phase phase){
-  // set all layers 
-  for (int i = 0; i < layers_.size(); ++i){
+void Net<Dtype>::SetPhase(Phase phase) {
+  // set all layers
+  for (int i = 0; i < layers_.size(); ++i) {
     layers_[i]->set_phase(phase);
   }
   // set net phase

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -256,6 +256,16 @@ void Net<Dtype>::Init(const NetParameter& in_param) {
 }
 
 template <typename Dtype>
+void Net<Dtype>::SetPhase(Phase phase){
+  // set all layers 
+  for (int i = 0; i < layers_.size(); ++i){
+    layers_[i]->set_phase(phase);
+  }
+  // set net phase
+  phase_ = phase;
+}
+
+template <typename Dtype>
 void Net<Dtype>::FilterNet(const NetParameter& param,
     NetParameter* param_filtered) {
   NetState net_state(param.state());
@@ -744,7 +754,7 @@ void Net<Dtype>::CopyTrainedLayersFrom(const NetParameter& param) {
       LOG(INFO) << "Ignoring source layer " << source_layer_name;
       continue;
     }
-    DLOG(INFO) << "Copying source layer " << source_layer_name;
+    LOG(INFO) << "Copying source layer " << source_layer_name;
     vector<shared_ptr<Blob<Dtype> > >& target_blobs =
         layers_[target_layer_id]->blobs();
     CHECK_EQ(target_blobs.size(), source_layer.blobs_size())

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -308,7 +308,7 @@ message ParamSpec {
 // NOTE
 // Update the next available ID when you add a new LayerParameter field.
 //
-// LayerParameter next available layer-specific ID: 150 (last added: psroi_pooling_param)
+// LayerParameter next available layer-specific ID: 151 (last added: box_annotator_ohem_param)
 message LayerParameter {
   optional string name = 1; // the layer name
   optional string type = 2; // the layer type
@@ -363,6 +363,7 @@ message LayerParameter {
   optional AccuracyParameter accuracy_param = 102;
   optional ArgMaxParameter argmax_param = 103;
   optional BatchNormParameter batch_norm_param = 139;
+  optional BoxAnnotatorOHEMParameter box_annotator_ohem_param = 150;
   optional BiasParameter bias_param = 141;
   optional ConcatParameter concat_param = 104;
   optional ContrastiveLossParameter contrastive_loss_param = 105;
@@ -391,7 +392,7 @@ message LayerParameter {
   optional PoolingParameter pooling_param = 121;
   optional PowerParameter power_param = 122;
   optional PReLUParameter prelu_param = 131;
-	optional PSROIPoolingParameter psroi_pooling_param = 149;
+  optional PSROIPoolingParameter psroi_pooling_param = 149;
   optional PythonParameter python_param = 130;
   optional RecurrentParameter recurrent_param = 146;
   optional ReductionParameter reduction_param = 136;
@@ -450,8 +451,10 @@ message LossParameter {
     VALID = 1;
     // Divide by the batch size.
     BATCH_SIZE = 2;
+    // Divide by pre-fixed normalizer
+    PRE_FIXED = 3;
     // Do not normalize the loss.
-    NONE = 3;
+    NONE = 4;
   }
   // For historical reasons, the default normalization for
   // SigmoidCrossEntropyLoss is BATCH_SIZE and *not* VALID.
@@ -460,6 +463,8 @@ message LossParameter {
   // is not specified, then setting this to false will be equivalent to
   // normalization = BATCH_SIZE to be consistent with previous behavior.
   optional bool normalize = 2;
+  //pre-fixed normalizer
+  optional float pre_fixed_normalizer = 4 [default = 1];
 }
 
 // Messages that store parameters used by individual layer types follow, in
@@ -524,6 +529,11 @@ message BatchNormParameter {
   // Small value to add to the variance estimate so that we don't divide by
   // zero.
   optional float eps = 3 [default = 1e-5];
+}
+
+message BoxAnnotatorOHEMParameter {
+  required uint32 roi_per_img = 1; // number of rois for training
+  optional int32 ignore_label = 2 [default = -1]; // ignore_label in scoring
 }
 
 message BiasParameter {
@@ -937,7 +947,7 @@ message PowerParameter {
 message PSROIPoolingParameter {
    required float spatial_scale = 1; 
    required int32 output_dim = 2; // output channel number
-   required int32 group_size = 3; // equal to pooled_size
+   required int32 group_size = 3; // number of groups to encode position-sensitive score maps
  }
 
 message PythonParameter {

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -308,7 +308,7 @@ message ParamSpec {
 // NOTE
 // Update the next available ID when you add a new LayerParameter field.
 //
-// LayerParameter next available layer-specific ID: 147 (last added: recurrent_param)
+// LayerParameter next available layer-specific ID: 150 (last added: psroi_pooling_param)
 message LayerParameter {
   optional string name = 1; // the layer name
   optional string type = 2; // the layer type
@@ -391,6 +391,7 @@ message LayerParameter {
   optional PoolingParameter pooling_param = 121;
   optional PowerParameter power_param = 122;
   optional PReLUParameter prelu_param = 131;
+	optional PSROIPoolingParameter psroi_pooling_param = 149;
   optional PythonParameter python_param = 130;
   optional RecurrentParameter recurrent_param = 146;
   optional ReductionParameter reduction_param = 136;
@@ -929,6 +930,12 @@ message PowerParameter {
   optional float scale = 2 [default = 1.0];
   optional float shift = 3 [default = 0.0];
 }
+
+message PSROIPoolingParameter {
+   required float spatial_scale = 1; 
+   required int32 output_dim = 2; // output channel number
+   required int32 group_size = 3; // equal to pooled_size
+ }
 
 message PythonParameter {
   optional string module = 1;

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -397,7 +397,7 @@ message LayerParameter {
   optional ReductionParameter reduction_param = 136;
   optional ReLUParameter relu_param = 123;
   optional ReshapeParameter reshape_param = 133;
-  optional ROIPoolingParameter roi_pooling_param = 146;
+  optional ROIPoolingParameter roi_pooling_param = 150;
   optional ScaleParameter scale_param = 142;
   optional SigmoidParameter sigmoid_param = 124;
   optional SmoothL1LossParameter smooth_l1_loss_param = 147;

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -397,8 +397,10 @@ message LayerParameter {
   optional ReductionParameter reduction_param = 136;
   optional ReLUParameter relu_param = 123;
   optional ReshapeParameter reshape_param = 133;
+  optional ROIPoolingParameter roi_pooling_param = 146;
   optional ScaleParameter scale_param = 142;
   optional SigmoidParameter sigmoid_param = 124;
+  optional SmoothL1LossParameter smooth_l1_loss_param = 147;
   optional SoftmaxParameter softmax_param = 125;
   optional SPPParameter spp_param = 132;
   optional SliceParameter slice_param = 126;
@@ -675,6 +677,7 @@ message DataParameter {
 
 message DropoutParameter {
   optional float dropout_ratio = 1 [default = 0.5]; // dropout ratio
+  optional bool scale_train = 2 [default = true];  // scale train or test phase
 }
 
 // DummyDataLayer fills any number of arbitrarily shaped blobs with random
@@ -1077,6 +1080,17 @@ message ReshapeParameter {
   optional int32 num_axes = 3 [default = -1];
 }
 
+// Message that stores parameters used by ROIPoolingLayer
+message ROIPoolingParameter {
+  // Pad, kernel size, and stride are all given as a single value for equal
+  // dimensions in height and width or as Y, X pairs.
+  optional uint32 pooled_h = 1 [default = 0]; // The pooled output height
+  optional uint32 pooled_w = 2 [default = 0]; // The pooled output width
+  // Multiplicative spatial scale factor to translate ROI coords from their
+  // input scale to the scale used when pooling
+  optional float spatial_scale = 3 [default = 1];
+}
+
 message ScaleParameter {
   // The first axis of bottom[0] (the first input Blob) along which to apply
   // bottom[1] (the second input Blob).  May be negative to index from the end
@@ -1132,6 +1146,13 @@ message SliceParameter {
 
   // DEPRECATED: alias for "axis" -- does not support negative indexing.
   optional uint32 slice_dim = 1 [default = 1];
+}
+
+message SmoothL1LossParameter {
+  // SmoothL1Loss(x) =
+  //   0.5 * (sigma * x) ** 2    -- if x < 1.0 / sigma / sigma
+  //   |x| - 0.5 / sigma / sigma -- otherwise
+  optional float sigma = 1 [default = 1];
 }
 
 // Message that stores parameters used by SoftmaxLayer, SoftmaxWithLossLayer

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -308,7 +308,7 @@ message ParamSpec {
 // NOTE
 // Update the next available ID when you add a new LayerParameter field.
 //
-// LayerParameter next available layer-specific ID: 151 (last added: box_annotator_ohem_param)
+// LayerParameter next available layer-specific ID: 152 (last added: box_annotator_ohem_param)
 message LayerParameter {
   optional string name = 1; // the layer name
   optional string type = 2; // the layer type
@@ -398,7 +398,7 @@ message LayerParameter {
   optional ReductionParameter reduction_param = 136;
   optional ReLUParameter relu_param = 123;
   optional ReshapeParameter reshape_param = 133;
-  optional ROIPoolingParameter roi_pooling_param = 150;
+  optional ROIPoolingParameter roi_pooling_param = 151;
   optional ScaleParameter scale_param = 142;
   optional SigmoidParameter sigmoid_param = 124;
   optional SmoothL1LossParameter smooth_l1_loss_param = 147;

--- a/src/caffe/test/test_roi_pooling_layer.cpp
+++ b/src/caffe/test/test_roi_pooling_layer.cpp
@@ -1,0 +1,93 @@
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+#include "boost/scoped_ptr.hpp"
+#include "gtest/gtest.h"
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/filler.hpp"
+#include "caffe/layers/roi_pooling_layer.hpp"
+#include "caffe/test/test_caffe_main.hpp"
+#include "caffe/test/test_gradient_check_util.hpp"
+
+using boost::scoped_ptr;
+
+namespace caffe {
+
+#ifndef CPU_ONLY
+template <typename Dtype>
+class ROIPoolingLayerTest : public GPUDeviceTest<Dtype> {
+ protected:
+  ROIPoolingLayerTest()
+      : blob_bottom_data_(new Blob<Dtype>(4, 3, 12, 8)),
+        blob_bottom_rois_(new Blob<Dtype>(4, 5, 1, 1)),
+        blob_top_data_(new Blob<Dtype>()) {
+    // fill the values
+    FillerParameter filler_param;
+    filler_param.set_std(10);
+    GaussianFiller<Dtype> filler(filler_param);
+    filler.Fill(this->blob_bottom_data_);
+
+    blob_bottom_vec_.push_back(blob_bottom_data_);
+
+    int i = 0;
+    // caffe_rng_rand() % 4;
+    blob_bottom_rois_->mutable_cpu_data()[0 + 5*i] = 0;
+    blob_bottom_rois_->mutable_cpu_data()[1 + 5*i] = 1;  // x1 < 8
+    blob_bottom_rois_->mutable_cpu_data()[2 + 5*i] = 1;  // y1 < 12
+    blob_bottom_rois_->mutable_cpu_data()[3 + 5*i] = 6;  // x2 < 8
+    blob_bottom_rois_->mutable_cpu_data()[4 + 5*i] = 6;  // y2 < 12
+    i = 1;
+    blob_bottom_rois_->mutable_cpu_data()[0 + 5*i] = 2;
+    blob_bottom_rois_->mutable_cpu_data()[1 + 5*i] = 6;  // x1 < 8
+    blob_bottom_rois_->mutable_cpu_data()[2 + 5*i] = 2;  // y1 < 12
+    blob_bottom_rois_->mutable_cpu_data()[3 + 5*i] = 7;  // x2 < 8
+    blob_bottom_rois_->mutable_cpu_data()[4 + 5*i] = 11;  // y2 < 12
+    i = 2;
+    blob_bottom_rois_->mutable_cpu_data()[0 + 5*i] = 1;
+    blob_bottom_rois_->mutable_cpu_data()[1 + 5*i] = 3;  // x1 < 8
+    blob_bottom_rois_->mutable_cpu_data()[2 + 5*i] = 1;  // y1 < 12
+    blob_bottom_rois_->mutable_cpu_data()[3 + 5*i] = 5;  // x2 < 8
+    blob_bottom_rois_->mutable_cpu_data()[4 + 5*i] = 10;  // y2 < 12
+    i = 3;
+    blob_bottom_rois_->mutable_cpu_data()[0 + 5*i] = 0;
+    blob_bottom_rois_->mutable_cpu_data()[1 + 5*i] = 3;  // x1 < 8
+    blob_bottom_rois_->mutable_cpu_data()[2 + 5*i] = 3;  // y1 < 12
+    blob_bottom_rois_->mutable_cpu_data()[3 + 5*i] = 3;  // x2 < 8
+    blob_bottom_rois_->mutable_cpu_data()[4 + 5*i] = 3;  // y2 < 12
+
+    blob_bottom_vec_.push_back(blob_bottom_rois_);
+    blob_top_vec_.push_back(blob_top_data_);
+  }
+  virtual ~ROIPoolingLayerTest() {
+    delete blob_bottom_data_;
+    delete blob_bottom_rois_;
+    delete blob_top_data_;
+  }
+  Blob<Dtype>* const blob_bottom_data_;
+  Blob<Dtype>* const blob_bottom_rois_;
+  Blob<Dtype>* const blob_top_data_;
+  vector<Blob<Dtype>*> blob_bottom_vec_;
+  vector<Blob<Dtype>*> blob_top_vec_;
+};
+
+// Forward and Backward CPU not implemented yet
+TYPED_TEST_CASE(ROIPoolingLayerTest, TestDtypes);
+
+TYPED_TEST(ROIPoolingLayerTest, TestGradient) {
+  LayerParameter layer_param;
+  ROIPoolingParameter* roi_pooling_param =
+      layer_param.mutable_roi_pooling_param();
+  roi_pooling_param->set_pooled_h(6);
+  roi_pooling_param->set_pooled_w(6);
+  ROIPoolingLayer<TypeParam> layer(layer_param);
+  GradientChecker<TypeParam> checker(1e-4, 1e-2);
+  checker.CheckGradientExhaustive(&layer, this->blob_bottom_vec_,
+      this->blob_top_vec_, 0);
+}
+#endif
+
+}  // namespace caffe

--- a/src/caffe/test/test_roi_pooling_layer.cpp
+++ b/src/caffe/test/test_roi_pooling_layer.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+#include <cfloat>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
@@ -17,77 +19,143 @@ using boost::scoped_ptr;
 
 namespace caffe {
 
-#ifndef CPU_ONLY
-template <typename Dtype>
-class ROIPoolingLayerTest : public GPUDeviceTest<Dtype> {
+template <typename TypeParam>
+class ROIPoolingLayerTest : public MultiDeviceTest<TypeParam> {
+  typedef typename TypeParam::Dtype Dtype;
+
  protected:
   ROIPoolingLayerTest()
-      : blob_bottom_data_(new Blob<Dtype>(4, 3, 12, 8)),
+      : blob_bottom_data_(new Blob<Dtype>(2, 2, 6, 8)),
         blob_bottom_rois_(new Blob<Dtype>(4, 5, 1, 1)),
-        blob_top_data_(new Blob<Dtype>()) {
+        blob_top_data_(new Blob<Dtype>()),
+        blob_bottom_data_2_(new Blob<Dtype>(2, 3, 12, 20)),
+        blob_bottom_rois_2_(new Blob<Dtype>(1, 5, 1, 1)),
+        blob_top_data_2_(new Blob<Dtype>()) {
     // fill the values
     FillerParameter filler_param;
     filler_param.set_std(10);
     GaussianFiller<Dtype> filler(filler_param);
     filler.Fill(this->blob_bottom_data_);
-
+    // for (int i = 0; i < blob_bottom_data_->count(); ++i) {
+    //   blob_bottom_data_->mutable_cpu_data()[i] = i;
+    // }
     blob_bottom_vec_.push_back(blob_bottom_data_);
-
     int i = 0;
-    // caffe_rng_rand() % 4;
     blob_bottom_rois_->mutable_cpu_data()[0 + 5*i] = 0;
-    blob_bottom_rois_->mutable_cpu_data()[1 + 5*i] = 1;  // x1 < 8
-    blob_bottom_rois_->mutable_cpu_data()[2 + 5*i] = 1;  // y1 < 12
-    blob_bottom_rois_->mutable_cpu_data()[3 + 5*i] = 6;  // x2 < 8
-    blob_bottom_rois_->mutable_cpu_data()[4 + 5*i] = 6;  // y2 < 12
-    i = 1;
-    blob_bottom_rois_->mutable_cpu_data()[0 + 5*i] = 2;
-    blob_bottom_rois_->mutable_cpu_data()[1 + 5*i] = 6;  // x1 < 8
-    blob_bottom_rois_->mutable_cpu_data()[2 + 5*i] = 2;  // y1 < 12
+    blob_bottom_rois_->mutable_cpu_data()[1 + 5*i] = 0;  // x1 < 8
+    blob_bottom_rois_->mutable_cpu_data()[2 + 5*i] = 0;  // y1 < 6
     blob_bottom_rois_->mutable_cpu_data()[3 + 5*i] = 7;  // x2 < 8
-    blob_bottom_rois_->mutable_cpu_data()[4 + 5*i] = 11;  // y2 < 12
+    blob_bottom_rois_->mutable_cpu_data()[4 + 5*i] = 5;  // y2 < 6
+    i = 1;
+    blob_bottom_rois_->mutable_cpu_data()[0 + 5*i] = 1;
+    blob_bottom_rois_->mutable_cpu_data()[1 + 5*i] = 6;  // x1 < 8
+    blob_bottom_rois_->mutable_cpu_data()[2 + 5*i] = 2;  // y1 < 6
+    blob_bottom_rois_->mutable_cpu_data()[3 + 5*i] = 7;  // x2 < 8
+    blob_bottom_rois_->mutable_cpu_data()[4 + 5*i] = 5;  // y2 < 6
     i = 2;
     blob_bottom_rois_->mutable_cpu_data()[0 + 5*i] = 1;
     blob_bottom_rois_->mutable_cpu_data()[1 + 5*i] = 3;  // x1 < 8
-    blob_bottom_rois_->mutable_cpu_data()[2 + 5*i] = 1;  // y1 < 12
-    blob_bottom_rois_->mutable_cpu_data()[3 + 5*i] = 5;  // x2 < 8
-    blob_bottom_rois_->mutable_cpu_data()[4 + 5*i] = 10;  // y2 < 12
+    blob_bottom_rois_->mutable_cpu_data()[2 + 5*i] = 1;  // y1 < 6
+    blob_bottom_rois_->mutable_cpu_data()[3 + 5*i] = 6;  // x2 < 8
+    blob_bottom_rois_->mutable_cpu_data()[4 + 5*i] = 4;  // y2 < 6
     i = 3;
     blob_bottom_rois_->mutable_cpu_data()[0 + 5*i] = 0;
     blob_bottom_rois_->mutable_cpu_data()[1 + 5*i] = 3;  // x1 < 8
-    blob_bottom_rois_->mutable_cpu_data()[2 + 5*i] = 3;  // y1 < 12
+    blob_bottom_rois_->mutable_cpu_data()[2 + 5*i] = 3;  // y1 < 6
     blob_bottom_rois_->mutable_cpu_data()[3 + 5*i] = 3;  // x2 < 8
-    blob_bottom_rois_->mutable_cpu_data()[4 + 5*i] = 3;  // y2 < 12
+    blob_bottom_rois_->mutable_cpu_data()[4 + 5*i] = 3;  // y2 < 6
 
     blob_bottom_vec_.push_back(blob_bottom_rois_);
     blob_top_vec_.push_back(blob_top_data_);
+
+    filler.Fill(this->blob_bottom_data_2_);
+    blob_bottom_vec_2_.push_back(blob_bottom_data_2_);
+
+    // Pool over the entire bottom of feature map 1
+    blob_bottom_rois_2_->mutable_cpu_data()[0] = 1;
+    blob_bottom_rois_2_->mutable_cpu_data()[1] = 0;
+    blob_bottom_rois_2_->mutable_cpu_data()[2] = 0;
+    blob_bottom_rois_2_->mutable_cpu_data()[3] = 19;
+    blob_bottom_rois_2_->mutable_cpu_data()[4] = 11;
+
+    blob_bottom_vec_2_.push_back(blob_bottom_rois_2_);
+    blob_top_vec_2_.push_back(blob_top_data_2_);
   }
   virtual ~ROIPoolingLayerTest() {
     delete blob_bottom_data_;
     delete blob_bottom_rois_;
     delete blob_top_data_;
+    delete blob_bottom_data_2_;
+    delete blob_bottom_rois_2_;
+    delete blob_top_data_2_;
   }
   Blob<Dtype>* const blob_bottom_data_;
   Blob<Dtype>* const blob_bottom_rois_;
   Blob<Dtype>* const blob_top_data_;
   vector<Blob<Dtype>*> blob_bottom_vec_;
   vector<Blob<Dtype>*> blob_top_vec_;
+
+  Blob<Dtype>* const blob_bottom_data_2_;
+  Blob<Dtype>* const blob_bottom_rois_2_;
+  Blob<Dtype>* const blob_top_data_2_;
+  vector<Blob<Dtype>*> blob_bottom_vec_2_;
+  vector<Blob<Dtype>*> blob_top_vec_2_;
 };
 
-// Forward and Backward CPU not implemented yet
-TYPED_TEST_CASE(ROIPoolingLayerTest, TestDtypes);
+TYPED_TEST_CASE(ROIPoolingLayerTest, TestDtypesAndDevices);
 
-TYPED_TEST(ROIPoolingLayerTest, TestGradient) {
+TYPED_TEST(ROIPoolingLayerTest, TestForward) {
+  typedef typename TypeParam::Dtype Dtype;
   LayerParameter layer_param;
   ROIPoolingParameter* roi_pooling_param =
       layer_param.mutable_roi_pooling_param();
+
+  // 12 x 20 pooling with bin_size_h == 1 && bin_size_w == 1
+  roi_pooling_param->set_pooled_h(12);
+  roi_pooling_param->set_pooled_w(20);
+  ROIPoolingLayer<Dtype> layer_2(layer_param);
+  layer_2.SetUp(this->blob_bottom_vec_2_, this->blob_top_vec_2_);
+  layer_2.Forward(this->blob_bottom_vec_2_, this->blob_top_vec_2_);
+  for (int i = 0; i < this->blob_top_data_2_->count(); ++i) {
+    EXPECT_EQ(this->blob_top_data_2_->cpu_data()[i],
+        this->blob_bottom_data_2_->cpu_data()[i+3*12*20]);
+  }
+
+  // 6 x 10 pooling with bin_size_h == 2 && bin_size_w == 2
   roi_pooling_param->set_pooled_h(6);
-  roi_pooling_param->set_pooled_w(6);
-  ROIPoolingLayer<TypeParam> layer(layer_param);
-  GradientChecker<TypeParam> checker(1e-4, 1e-2);
+  roi_pooling_param->set_pooled_w(10);
+  ROIPoolingLayer<Dtype> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_2_, this->blob_top_vec_2_);
+  layer.Forward(this->blob_bottom_vec_2_, this->blob_top_vec_2_);
+  int n = 1;
+  for (int c = 0; c < 3; ++c) {
+    for (int ph = 0; ph < 6; ++ph) {
+      for (int pw = 0; pw < 10; ++pw) {
+        Dtype maxval = -FLT_MAX;
+        for (int h = 2 * ph; h < 2 * (ph + 1); ++h) {
+          for (int w = 2 * pw; w < 2 * (pw + 1); ++w) {
+            maxval = std::max(maxval, this->blob_bottom_data_2_->cpu_data()[
+                ((n * 3 + c) * 12 + h) * 20 + w]);
+          }
+        }
+        EXPECT_EQ(this->blob_top_data_2_->cpu_data()[(c * 6 + ph) * 10 + pw],
+            maxval);
+      }
+    }
+  }
+}
+
+TYPED_TEST(ROIPoolingLayerTest, TestGradient) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param;
+  ROIPoolingParameter* roi_pooling_param =
+      layer_param.mutable_roi_pooling_param();
+  roi_pooling_param->set_pooled_h(3);
+  roi_pooling_param->set_pooled_w(4);
+  ROIPoolingLayer<Dtype> layer(layer_param);
+  GradientChecker<Dtype> checker(1e-4, 1e-2);
   checker.CheckGradientExhaustive(&layer, this->blob_bottom_vec_,
       this->blob_top_vec_, 0);
 }
-#endif
 
 }  // namespace caffe

--- a/src/caffe/test/test_smooth_l1_loss_layer.cpp
+++ b/src/caffe/test/test_smooth_l1_loss_layer.cpp
@@ -1,0 +1,85 @@
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/filler.hpp"
+#include "caffe/layers/smooth_l1_loss_layer.hpp"
+#include "caffe/test/test_caffe_main.hpp"
+#include "caffe/test/test_gradient_check_util.hpp"
+
+namespace caffe {
+
+#ifndef CPU_ONLY
+template <typename Dtype>
+class SmoothL1LossLayerTest : public GPUDeviceTest<Dtype> {
+ protected:
+  SmoothL1LossLayerTest()
+      : blob_bottom_data_(new Blob<Dtype>(10, 5, 1, 1)),
+        blob_bottom_label_(new Blob<Dtype>(10, 5, 1, 1)),
+        blob_bottom_inside_weights_(new Blob<Dtype>(10, 5, 1, 1)),
+        blob_bottom_outside_weights_(new Blob<Dtype>(10, 5, 1, 1)),
+        blob_top_loss_(new Blob<Dtype>()) {
+    // fill the values
+    FillerParameter const_filler_param;
+    const_filler_param.set_value(-1.);
+    ConstantFiller<Dtype> const_filler(const_filler_param);
+    FillerParameter filler_param;
+    GaussianFiller<Dtype> filler(filler_param);
+
+    filler.Fill(this->blob_bottom_data_);
+    blob_bottom_vec_.push_back(blob_bottom_data_);
+
+    filler.Fill(this->blob_bottom_label_);
+    blob_bottom_vec_.push_back(blob_bottom_label_);
+
+    filler.Fill(this->blob_bottom_inside_weights_);
+    blob_bottom_vec_.push_back(blob_bottom_inside_weights_);
+
+    filler.Fill(this->blob_bottom_outside_weights_);
+    blob_bottom_vec_.push_back(blob_bottom_outside_weights_);
+
+    blob_top_vec_.push_back(blob_top_loss_);
+  }
+  virtual ~SmoothL1LossLayerTest() {
+    delete blob_bottom_data_;
+    delete blob_bottom_label_;
+    delete blob_bottom_inside_weights_;
+    delete blob_bottom_outside_weights_;
+    delete blob_top_loss_;
+  }
+
+  Blob<Dtype>* const blob_bottom_data_;
+  Blob<Dtype>* const blob_bottom_label_;
+  Blob<Dtype>* const blob_bottom_inside_weights_;
+  Blob<Dtype>* const blob_bottom_outside_weights_;
+  Blob<Dtype>* const blob_top_loss_;
+  vector<Blob<Dtype>*> blob_bottom_vec_;
+  vector<Blob<Dtype>*> blob_top_vec_;
+};
+
+TYPED_TEST_CASE(SmoothL1LossLayerTest, TestDtypes);
+
+TYPED_TEST(SmoothL1LossLayerTest, TestGradient) {
+  LayerParameter layer_param;
+  SmoothL1LossParameter* loss_param =
+      layer_param.mutable_smooth_l1_loss_param();
+  loss_param->set_sigma(2.4);
+
+  const TypeParam kLossWeight = 3.7;
+  layer_param.add_loss_weight(kLossWeight);
+  SmoothL1LossLayer<TypeParam> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  GradientChecker<TypeParam> checker(1e-2, 1e-2, 1701);
+  checker.CheckGradientExhaustive(&layer, this->blob_bottom_vec_,
+      this->blob_top_vec_, 0);
+  checker.CheckGradientExhaustive(&layer, this->blob_bottom_vec_,
+      this->blob_top_vec_, 1);
+}
+#endif
+
+}  // namespace caffe


### PR DESCRIPTION
Bounding box detection service relies on the code from the Microsoft fork of Caffe (https://github.com/Microsoft/caffe) which is no longer maintained and the repo where they direct everyone to use doesn't have all the code from their original repo.

This PR pulls down all the changes related to FRCNN (which we use for bounding box detections) into the fork of the Caffe from their V1 main-line.

