### PR TITLE
DEV-28294: Modify Makefile to include c++11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,10 +316,10 @@ endif
 
 # Debugging
 ifeq ($(DEBUG), 1)
-	COMMON_FLAGS += -DDEBUG -g -O0
+	COMMON_FLAGS += -DDEBUG -g -O0 -std=c++11
 	NVCCFLAGS += -G
 else
-	COMMON_FLAGS += -DNDEBUG -O2
+	COMMON_FLAGS += -DNDEBUG -O2 -std=c++11
 endif
 
 # cuDNN acceleration configuration.


### PR DESCRIPTION
https://curalate.atlassian.net/browse/DEV-28294

Add the c++11 flag to the Makefile, which we need to compile the OHEM layer.