### PR TITLE
dev-31752: FRCNN layers should use opencv 3.

### DIFF
--- a/include/caffe/util/frcnn_utils.hpp
+++ b/include/caffe/util/frcnn_utils.hpp
@@ -22,7 +22,6 @@
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
-#include <opencv2/contrib/contrib.hpp>
 #include <boost/algorithm/string.hpp>
 #include "boost/filesystem.hpp"
 


### PR DESCRIPTION
In opencv 3 `opencv2/contrib/contrib.hpp` doesn't exist anymore.