### PR TITLE
DEV-41864: Add support for Cudnn 7 to our caffe branch

### DIFF
--- a/include/caffe/util/cudnn.hpp
+++ b/include/caffe/util/cudnn.hpp
@@ -45,8 +45,14 @@ inline const char* cudnnGetErrorString(cudnnStatus_t status) {
     case CUDNN_STATUS_RUNTIME_PREREQUISITE_MISSING:
       return "CUDNN_STATUS_RUNTIME_PREREQUISITE_MISSING";
 #endif
-  }
-  return "Unknown cudnn status";
+#if CUDNN_VERSION_MIN(7, 0, 0)
+    case CUDNN_STATUS_RUNTIME_IN_PROGRESS:
+      return "CUDNN_STATUS_RUNTIME_IN_PROGRESS";
+    case CUDNN_STATUS_RUNTIME_FP_OVERFLOW:
+      return "CUDNN_STATUS_RUNTIME_FP_OVERFLOW";
+#endif
+    }
+    return "Unknown cudnn status";
 }
 
 namespace caffe {


### PR DESCRIPTION
Rebuilding Caffe in the current state of our docker images/release AMIs for spam

Need to get it building with Cudnn 7 installed. 